### PR TITLE
Fix import grouping when expandRelative is set to true

### DIFF
--- a/input/src/main/scala/fix/ExpandRelativeMultiGroups.scala
+++ b/input/src/main/scala/fix/ExpandRelativeMultiGroups.scala
@@ -1,0 +1,17 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groups = ["re:javax?\\.", "scala.", "*"]
+  expandRelative = true
+}
+ */
+
+package fix
+
+import scala.util
+import java.time.Clock
+import util.control
+import javax.management.JMX
+import control.NonFatal
+
+object ExpandRelativeMultiGroups

--- a/output/src/main/scala/fix/ExpandRelativeMultiGroups.scala
+++ b/output/src/main/scala/fix/ExpandRelativeMultiGroups.scala
@@ -1,0 +1,10 @@
+package fix
+
+import java.time.Clock
+import javax.management.JMX
+
+import scala.util
+import scala.util.control
+import scala.util.control.NonFatal
+
+object ExpandRelativeMultiGroups


### PR DESCRIPTION
Two facts caused issue #1:

- `OrganizeImports` leverages symbol table information to check whether an import expression is fully-qualified.
- When `config.expandRelative` is set to true, fully-qualified import expressions returned by the `expandRelative()` method contain synthesized AST nodes without symbols associated with them.

This PR fixes this issue by also checking `config.expandRelative` while partitioning fully-qualified and relative import expressions.