### PR TITLE
Remove unused imports

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,1 +1,3 @@
 rules = [OrganizeImports]
+
+OrganizeImports.removeUnused = true

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,6 @@ inThisBuild(
     ),
     scalaVersion := v.scala212,
     scalacOptions ++= List(
-      "-Ywarn-unused",
       "-Yrangepos",
       "-P:semanticdb:synthetics:on"
     ),
@@ -32,26 +31,45 @@ lazy val rules = project
     moduleName := "organize-imports",
     conflictManager := ConflictManager.strict,
     dependencyOverrides += "com.lihaoyi" %% "sourcecode" % "0.2.1",
-    libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % v.scalafixVersion
+    libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % v.scalafixVersion,
+    scalacOptions ++= List("-Ywarn-unused")
   )
 
 lazy val input = project.settings(skip in publish := true)
 
 lazy val output = project.settings(skip in publish := true)
 
+lazy val inputUnusedImports = project
+  .settings(
+    skip in publish := true,
+    scalacOptions ++= List("-Ywarn-unused")
+  )
+
 lazy val tests = project
   .dependsOn(rules)
   .enablePlugins(ScalafixTestkitPlugin)
   .settings(
     skip in publish := true,
+    scalacOptions ++= List("-Ywarn-unused"),
     libraryDependencies +=
       "ch.epfl.scala" % "scalafix-testkit" % v.scalafixVersion % Test cross CrossVersion.full,
     dependencyOverrides ++= List(
       "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
       "org.slf4j" % "slf4j-api" % "1.7.25"
     ),
-    (compile in Compile) := ((compile in Compile) dependsOn (compile in (input, Compile))).value,
-    scalafixTestkitOutputSourceDirectories := (sourceDirectories in (output, Compile)).value,
-    scalafixTestkitInputSourceDirectories := (sourceDirectories in (input, Compile)).value,
-    scalafixTestkitInputClasspath := (fullClasspath in (input, Compile)).value
+    (compile in Compile) := (compile in Compile)
+      .dependsOn(
+        compile in (input, Compile),
+        compile in (inputUnusedImports, Compile)
+      )
+      .value,
+    scalafixTestkitOutputSourceDirectories := sourceDirectories.in(output, Compile).value,
+    scalafixTestkitInputSourceDirectories := (
+      sourceDirectories.in(input, Compile).value ++
+        sourceDirectories.in(inputUnusedImports, Compile).value
+    ),
+    scalafixTestkitInputClasspath := (
+      fullClasspath.in(input, Compile).value ++
+        fullClasspath.in(inputUnusedImports, Compile).value
+    ).distinct
   )

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ inThisBuild(
     ),
     scalaVersion := v.scala212,
     scalacOptions ++= List(
+      "-Ywarn-unused",
       "-Yrangepos",
       "-P:semanticdb:synthetics:on"
     ),

--- a/input/src/main/scala/fix/RemoveUnused.scala
+++ b/input/src/main/scala/fix/RemoveUnused.scala
@@ -1,0 +1,18 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groups = ["re:javax?\\.", "scala.", "*"]
+  removeUnused = true
+}
+ */
+
+package fix
+
+import scala.collection.mutable.{Buffer, ArrayBuffer}
+import java.time.Clock
+import java.lang.{Long => JLong, Double => JDouble}
+
+object RemoveUnused {
+  val buffer: ArrayBuffer[Int] = ArrayBuffer.empty[Int]
+  val long: JLong = JLong.parseLong("0")
+}

--- a/inputUnusedImports/src/main/scala/fix/RemoveUnused.scala
+++ b/inputUnusedImports/src/main/scala/fix/RemoveUnused.scala
@@ -8,7 +8,7 @@ OrganizeImports {
 
 package fix
 
-import scala.collection.mutable.{Buffer, ArrayBuffer}
+import scala.collection.mutable.{ArrayBuffer, Buffer}
 import java.time.Clock
 import java.lang.{Long => JLong, Double => JDouble}
 

--- a/output/src/main/scala/fix/RemoveUnused.scala
+++ b/output/src/main/scala/fix/RemoveUnused.scala
@@ -1,0 +1,10 @@
+package fix
+
+import java.lang.{Long => JLong}
+
+import scala.collection.mutable.ArrayBuffer
+
+object RemoveUnused {
+  val buffer: ArrayBuffer[Int] = ArrayBuffer.empty[Int]
+  val long: JLong = JLong.parseLong("0")
+}

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -10,12 +10,12 @@ import scala.meta.Source
 import scala.meta.Stat
 import scala.meta.Term
 import scala.meta.Tree
-import scala.meta.inputs.Position
 import scala.util.matching.Regex
 
 import metaconfig.Configured
 import scalafix.patch.Patch
 import scalafix.v1._
+import scala.meta.inputs.Position
 
 class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("OrganizeImports") {
   import OrganizeImports._
@@ -69,13 +69,13 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
           .map(_.position)
           .toSet
 
+      def importeePosition(importee: Importee): Position = importee match {
+        case Importee.Rename(from, _) => from.pos
+        case _                        => importee.pos
+      }
+
       val unusedRemoved = importer.importees filterNot { importee =>
-        unusedImports contains (
-          importee match {
-            case Importee.Rename(from, _) => from.pos
-            case _                        => importee.pos
-          }
-        )
+        unusedImports contains importeePosition(importee)
       }
 
       if (unusedRemoved.isEmpty) Nil

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -10,6 +10,7 @@ import scala.meta.Source
 import scala.meta.Stat
 import scala.meta.Term
 import scala.meta.Tree
+import scala.meta.inputs.Position
 import scala.util.matching.Regex
 
 import metaconfig.Configured
@@ -36,14 +37,50 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
 
   override def isExperimental: Boolean = true
 
-  override def withConfiguration(config: Configuration): Configured[Rule] = {
-    config.conf.getOrElse("OrganizeImports")(OrganizeImportsConfig()).map(new OrganizeImports(_))
-  }
+  override def withConfiguration(config: Configuration): Configured[Rule] =
+    config.conf.getOrElse("OrganizeImports")(OrganizeImportsConfig()) andThen { conf =>
+      val hasWarnUnused = {
+        val warnUnusedPrefix = Set("-Wunused", "-Ywarn-unused")
+        config.scalacOptions exists { option => warnUnusedPrefix exists (option.startsWith _) }
+      }
+
+      if (hasWarnUnused || !conf.removeUnused)
+        Configured.ok(new OrganizeImports(conf))
+      else
+        Configured.error(
+          "The Scala compiler option \"-Ywarn-unused\" is required to use OrganizeImports with"
+            + " \"OrganizeImports.removeUnused\" set to true. To fix this problem, update your"
+            + " build to use at least one Scala compiler option that starts with -Ywarn-unused"
+            + " or -Wunused (2.13 only)"
+        )
+    }
 
   override def fix(implicit doc: SemanticDocument): Patch = {
     val globalImports = collectGlobalImports(doc.tree)
     if (globalImports.isEmpty) Patch.empty else organizeImports(globalImports)
   }
+
+  private def removeUnused(importer: Importer)(implicit doc: SemanticDocument): Seq[Importer] =
+    if (!config.removeUnused) importer :: Nil
+    else {
+      val unusedImports =
+        doc.diagnostics
+          .filter(_.message == "Unused import")
+          .map(_.position)
+          .toSet
+
+      val unusedRemoved = importer.importees filterNot { importee =>
+        unusedImports contains (
+          importee match {
+            case Importee.Rename(from, _) => from.pos
+            case _                        => importee.pos
+          }
+        )
+      }
+
+      if (unusedRemoved.isEmpty) Nil
+      else importer.copy(importees = unusedRemoved) :: Nil
+    }
 
   private def organizeImports(imports: Seq[Import])(implicit doc: SemanticDocument): Patch = {
     val (fullyQualifiedImporters, relativeImporters) =
@@ -58,6 +95,7 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
     // Organizes all the fully-qualified global importers.
     val (_, sortedImporterGroups: Seq[Seq[Importer]]) =
       fullyQualifiedImporters
+        .flatMap(removeUnused)
         .groupBy(matchImportGroup) // Groups imports by importer prefix.
         .mapValues(organizeImporters) // Organize imports within the same group.
         .toSeq
@@ -68,7 +106,7 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
     // order unchanged.
     val organizedImporterGroups: Seq[Seq[Importer]] =
       if (relativeImporters.isEmpty) sortedImporterGroups
-      else sortedImporterGroups :+ relativeImporters
+      else sortedImporterGroups :+ relativeImporters.flatMap(removeUnused)
 
     // A patch that removes all the tokens forming the original imports.
     val removeOriginalImports = Patch.removeTokens(

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -246,7 +246,7 @@ object OrganizeImports {
 
   private def explodeGroupedImportees(importers: Seq[Importer]): Seq[Importer] =
     importers.flatMap {
-      case importer @ Importer(ref, importees) =>
+      case Importer(ref, importees) =>
         var containsUnimport = false
         var containsWildcard = false
 

--- a/rules/src/main/scala/fix/OrganizeImportsConfig.scala
+++ b/rules/src/main/scala/fix/OrganizeImportsConfig.scala
@@ -34,7 +34,8 @@ final case class OrganizeImportsConfig(
   expandRelative: Boolean = false,
   importSelectorsOrder: ImportSelectorsOrder = ImportSelectorsOrder.Ascii,
   groupedImports: GroupedImports = GroupedImports.Explode,
-  groups: Seq[String] = Seq("re:javax?\\.", "scala.", "*")
+  groups: Seq[String] = Seq("re:javax?\\.", "scala.", "*"),
+  removeUnused: Boolean = false
 )
 
 object OrganizeImportsConfig {


### PR DESCRIPTION
If the `Patch`es generated by two Scalafix rules overlap, they may step upon each other's toes and generate wrong output. Therefore, it is not feasible to run `OrganizeImports` together with the built-in `RemoveUnused` rule to remove unused imports.

In order to make `OrganizeImports` more self-contained, this PR ports the remove-unused-imports feature from the built-in `RemoveUnused` rule to `OrganizeImports`.

One limitation of the current implementation is that, when `expandRelative` is enabled, `OrganizeImports` may generate new unused imports, and those cannot be cleanly removed. This is because we are using compilation diagnostics to find unused imports.