### PR TITLE
Group imports by longest prefix match

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -227,6 +227,21 @@ import control.NonFatal
 
 CAUTION: Comments living _between_ imports being processed will be _removed_.
 
+[TIP]
+====
+`OrganizeImports` tries to match the longest prefix while grouping imports. For instance, the following configuration groups `scala.meta.` and `scala.` imports into different two groups properly:
+
+[source,hocon]
+----
+OrganizeImports.groups = [
+  "re:javax?\\."
+  "scala."
+  "scala.meta."
+  "*"
+]
+----
+====
+
 ==== Value type
 
 An ordered list of import prefix pattern strings. A prefix pattern can be one of the following:

--- a/input/src/main/scala/fix/OrganizeImportsLongestMatch.scala
+++ b/input/src/main/scala/fix/OrganizeImportsLongestMatch.scala
@@ -1,0 +1,16 @@
+/*
+rules = OrganizeImports
+OrganizeImports.groups = ["re:javax?\\.", "scala.", "scala.util.", "*"]
+ */
+
+package fix
+
+import java.time.Clock
+import scala.collection.JavaConverters._
+import sun.misc.BASE64Encoder
+import scala.concurrent.ExecutionContext
+import javax.annotation.Generated
+import scala.util.control.NonFatal
+import scala.util.Random
+
+object OrganizeImportsLongestMatch

--- a/output/src/main/scala/fix/OrganizeImportsLongestMatch.scala
+++ b/output/src/main/scala/fix/OrganizeImportsLongestMatch.scala
@@ -1,0 +1,14 @@
+package fix
+
+import java.time.Clock
+import javax.annotation.Generated
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+import scala.util.Random
+import scala.util.control.NonFatal
+
+import sun.misc.BASE64Encoder
+
+object OrganizeImportsLongestMatch

--- a/rules/src/main/scala/fix/ImportMatcher.scala
+++ b/rules/src/main/scala/fix/ImportMatcher.scala
@@ -4,19 +4,20 @@ import scala.meta.Importer
 import scala.util.matching.Regex
 
 sealed trait ImportMatcher {
-  def matches(i: Importer): Boolean
+  def matches(i: Importer): Int
 }
 
 case class RegexMatcher(pattern: Regex) extends ImportMatcher {
-  override def matches(i: Importer): Boolean = (pattern findPrefixMatchOf i.syntax).nonEmpty
+  override def matches(i: Importer): Int =
+    pattern findPrefixMatchOf i.syntax map (_.end) getOrElse 0
 }
 
 case class PlainTextMatcher(pattern: String) extends ImportMatcher {
-  override def matches(i: Importer): Boolean = i.syntax startsWith pattern
+  override def matches(i: Importer): Int = if (i.syntax startsWith pattern) pattern.length else 0
 }
 
 case object WildcardMatcher extends ImportMatcher {
   // This matcher should not match anything. The wildcard group is always special-cased at the end
   // of the import group matching process.
-  def matches(importer: Importer): Boolean = false
+  def matches(importer: Importer): Int = 0
 }

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -183,8 +183,16 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
 
   // Returns the index of the group to which the given importer belongs.
   private def matchImportGroup(importer: Importer): Int = {
-    val index = importMatchers indexWhere (_ matches importer)
-    if (index > -1) index else wildcardGroupIndex
+    val matchedGroups = importMatchers
+      .map(_ matches importer)
+      .zipWithIndex
+      .filter { case (length, _) => length > 0 }
+
+    if (matchedGroups.isEmpty) wildcardGroupIndex
+    else {
+      val (_, index) = matchedGroups.maxBy { case (length, _) => length }
+      index
+    }
   }
 }
 


### PR DESCRIPTION
Previously, the following configuration cannot move `scala.meta.` imports into a separate group. Instead, they are moved into the `scala.` group incorrectly.

```hocon
OrganizeImports.groups {
  "scala."
  "scala.meta."
}
```

This PR checks for the longest prefix match while grouping imports to fix this issue.