### PR TITLE
Re-enable the quoted-identifier test case

### DIFF
--- a/input/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
+++ b/input/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
@@ -5,9 +5,8 @@ OrganizeImports.expandRelative = true
 
 package fix
 
-// TODO Re-enable this test case after scalacenter/scalafix#1097 is fixed.
-// import ExpandRelativeQuotedIdent.`a.b`
-// import `a.b`.c
+import ExpandRelativeQuotedIdent.`a.b`
+import `a.b`.c
 
 object ExpandRelativeQuotedIdent {
   object `a.b` {

--- a/output/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
+++ b/output/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
@@ -1,8 +1,7 @@
 package fix
 
-// TODO Re-enable this test case after scalacenter/scalafix#1097 is fixed.
-// import ExpandRelativeQuotedIdent.`a.b`
-// import `a.b`.c
+import fix.ExpandRelativeQuotedIdent.`a.b`
+import fix.ExpandRelativeQuotedIdent.`a.b`.c
 
 object ExpandRelativeQuotedIdent {
   object `a.b` {


### PR DESCRIPTION
Issue #2 has been fixed by upgrading `sbt-scalafix` to v0.9.15 in commit d217343e89070ab359bf47bc98743206c5f2ea18.

This PR re-enable the previously disabled quoted-identifier test case to verify the fix.