### PR TITLE
Wildcard should always appear at last in a grouped import

### DIFF
--- a/input/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/input/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -1,0 +1,11 @@
+/*
+rules = OrganizeImports
+OrganizeImports.groupedImports = Merge
+OrganizeImports.importSelectorsOrder = Ascii
+ */
+package fix
+
+import scala.collection.mutable
+import scala.collection._
+
+object GroupedImportsMergeWildcard

--- a/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -1,0 +1,5 @@
+package fix
+
+import scala.collection.{mutable, _}
+
+object GroupedImportsMergeWildcard


### PR DESCRIPTION
While sorting import selectors, no matter what order is used, as requested by Scala spec, wildcard must always appear at last.