### PR TITLE
Fix various corner cases while merging imports with the same prefix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,9 +39,11 @@ lazy val rules = project
     scalacOptions ++= List("-Ywarn-unused")
   )
 
-lazy val input = project.settings(skip in publish := true)
+lazy val shared = project.settings(skip in publish := true)
 
-lazy val output = project.settings(skip in publish := true)
+lazy val input = project.settings(skip in publish := true).dependsOn(shared)
+
+lazy val output = project.settings(skip in publish := true).dependsOn(shared)
 
 lazy val inputUnusedImports = project
   .settings(

--- a/input/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
+++ b/input/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
@@ -5,11 +5,9 @@ OrganizeImports.expandRelative = true
 
 package fix
 
-import ExpandRelativeQuotedIdent.`a.b`
+import QuotedIdent.`a.b`
 import `a.b`.c
 
 object ExpandRelativeQuotedIdent {
-  object `a.b` {
-    object c
-  }
+  val refC = c
 }

--- a/input/src/main/scala/fix/GroupedImportsMergeRenames.scala
+++ b/input/src/main/scala/fix/GroupedImportsMergeRenames.scala
@@ -1,0 +1,19 @@
+/*
+rules = OrganizeImports
+OrganizeImports.groupedImports = Merge
+OrganizeImports.importSelectorsOrder = Ascii
+ */
+package fix
+
+import fix.MergeImports.Rename1.{a => A}
+import fix.MergeImports.Rename1.{b => B}
+import fix.MergeImports.Rename1.c
+import fix.MergeImports.Rename1.d
+
+import fix.MergeImports.Rename2.a
+import fix.MergeImports.Rename2.{a => A}
+import fix.MergeImports.Rename2.b
+import fix.MergeImports.Rename2.{b => B}
+import fix.MergeImports.Rename2.c
+
+object GroupedImportsMergeRenames

--- a/input/src/main/scala/fix/GroupedImportsMergeUnimports.scala
+++ b/input/src/main/scala/fix/GroupedImportsMergeUnimports.scala
@@ -1,0 +1,13 @@
+/*
+rules = OrganizeImports
+OrganizeImports.groupedImports = Merge
+OrganizeImports.importSelectorsOrder = Ascii
+ */
+package fix
+
+import fix.MergeImports.Unimport.{a => _, _}
+import fix.MergeImports.Unimport.{b => B}
+import fix.MergeImports.Unimport.{c => _, _}
+import fix.MergeImports.Unimport.d
+
+object GroupedImportsMergeUnimports

--- a/input/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/input/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -5,53 +5,13 @@ OrganizeImports.importSelectorsOrder = Ascii
  */
 package fix
 
-import fix.P._
-import fix.P.{a => _, _}
-import fix.P.{b => B}
-import fix.P.{c => _, _}
-import fix.P.d
+import fix.MergeImports.Wildcard1._
+import fix.MergeImports.Wildcard1.{a => _, _}
+import fix.MergeImports.Wildcard1.{b => B}
+import fix.MergeImports.Wildcard1.{c => _, _}
+import fix.MergeImports.Wildcard1.d
 
-import fix.Q.{a => _, _}
-import fix.Q.{b => B}
-import fix.Q.{c => _, _}
-import fix.Q.d
-
-import fix.R.{a => A}
-import fix.R.{b => B}
-import fix.R.c
-import fix.R.d
-
-import fix.S.a
-import fix.S.b
-import fix.S.c
-import fix.S.{a => a1}
-import fix.S.{b => b1}
-
-object P {
-  val a = ???
-  val b = ???
-  val c = ???
-  val d = ???
-}
-
-object Q {
-  val a = ???
-  val b = ???
-  val c = ???
-  val d = ???
-}
-
-object R {
-  val a = ???
-  val b = ???
-  val c = ???
-  val d = ???
-}
-
-object S {
-  val a = ???
-  val b = ???
-  val c = ???
-}
+import fix.MergeImports.Wildcard2._
+import fix.MergeImports.Wildcard2.{a, b}
 
 object GroupedImportsMergeWildcard

--- a/input/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/input/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -5,53 +5,53 @@ OrganizeImports.importSelectorsOrder = Ascii
  */
 package fix
 
-import fix.GroupedImportsMergeWildcard.P._
-import fix.GroupedImportsMergeWildcard.P.{a => _, _}
-import fix.GroupedImportsMergeWildcard.P.{b => B}
-import fix.GroupedImportsMergeWildcard.P.{c => _, _}
-import fix.GroupedImportsMergeWildcard.P.d
+import fix.P._
+import fix.P.{a => _, _}
+import fix.P.{b => B}
+import fix.P.{c => _, _}
+import fix.P.d
 
-import fix.GroupedImportsMergeWildcard.Q.{a => _, _}
-import fix.GroupedImportsMergeWildcard.Q.{b => B}
-import fix.GroupedImportsMergeWildcard.Q.{c => _, _}
-import fix.GroupedImportsMergeWildcard.Q.d
+import fix.Q.{a => _, _}
+import fix.Q.{b => B}
+import fix.Q.{c => _, _}
+import fix.Q.d
 
-import fix.GroupedImportsMergeWildcard.R.{a => A}
-import fix.GroupedImportsMergeWildcard.R.{b => B}
-import fix.GroupedImportsMergeWildcard.R.c
-import fix.GroupedImportsMergeWildcard.R.d
+import fix.R.{a => A}
+import fix.R.{b => B}
+import fix.R.c
+import fix.R.d
 
-import fix.GroupedImportsMergeWildcard.S.a
-import fix.GroupedImportsMergeWildcard.S.b
-import fix.GroupedImportsMergeWildcard.S.c
-import fix.GroupedImportsMergeWildcard.S.{a => a1}
-import fix.GroupedImportsMergeWildcard.S.{b => b1}
+import fix.S.a
+import fix.S.b
+import fix.S.c
+import fix.S.{a => a1}
+import fix.S.{b => b1}
 
-object GroupedImportsMergeWildcard {
-  object P {
-    val a = ???
-    val b = ???
-    val c = ???
-    val d = ???
-  }
-
-  object Q {
-    val a = ???
-    val b = ???
-    val c = ???
-    val d = ???
-  }
-
-  object R {
-    val a = ???
-    val b = ???
-    val c = ???
-    val d = ???
-  }
-  
-  object S {
-    val a = ???
-    val b = ???
-    val c = ???
-  }
+object P {
+  val a = ???
+  val b = ???
+  val c = ???
+  val d = ???
 }
+
+object Q {
+  val a = ???
+  val b = ???
+  val c = ???
+  val d = ???
+}
+
+object R {
+  val a = ???
+  val b = ???
+  val c = ???
+  val d = ???
+}
+
+object S {
+  val a = ???
+  val b = ???
+  val c = ???
+}
+
+object GroupedImportsMergeWildcard

--- a/input/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/input/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -5,7 +5,53 @@ OrganizeImports.importSelectorsOrder = Ascii
  */
 package fix
 
-import scala.collection.mutable
-import scala.collection._
+import fix.GroupedImportsMergeWildcard.P._
+import fix.GroupedImportsMergeWildcard.P.{a => _, _}
+import fix.GroupedImportsMergeWildcard.P.{b => B}
+import fix.GroupedImportsMergeWildcard.P.{c => _, _}
+import fix.GroupedImportsMergeWildcard.P.d
 
-object GroupedImportsMergeWildcard
+import fix.GroupedImportsMergeWildcard.Q.{a => _, _}
+import fix.GroupedImportsMergeWildcard.Q.{b => B}
+import fix.GroupedImportsMergeWildcard.Q.{c => _, _}
+import fix.GroupedImportsMergeWildcard.Q.d
+
+import fix.GroupedImportsMergeWildcard.R.{a => A}
+import fix.GroupedImportsMergeWildcard.R.{b => B}
+import fix.GroupedImportsMergeWildcard.R.c
+import fix.GroupedImportsMergeWildcard.R.d
+
+import fix.GroupedImportsMergeWildcard.S.a
+import fix.GroupedImportsMergeWildcard.S.b
+import fix.GroupedImportsMergeWildcard.S.c
+import fix.GroupedImportsMergeWildcard.S.{a => a1}
+import fix.GroupedImportsMergeWildcard.S.{b => b1}
+
+object GroupedImportsMergeWildcard {
+  object P {
+    val a = ???
+    val b = ???
+    val c = ???
+    val d = ???
+  }
+
+  object Q {
+    val a = ???
+    val b = ???
+    val c = ???
+    val d = ???
+  }
+
+  object R {
+    val a = ???
+    val b = ???
+    val c = ???
+    val d = ???
+  }
+  
+  object S {
+    val a = ???
+    val b = ???
+    val c = ???
+  }
+}

--- a/output/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
+++ b/output/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
@@ -1,10 +1,8 @@
 package fix
 
-import fix.ExpandRelativeQuotedIdent.`a.b`
-import fix.ExpandRelativeQuotedIdent.`a.b`.c
+import fix.QuotedIdent.`a.b`
+import fix.QuotedIdent.`a.b`.c
 
 object ExpandRelativeQuotedIdent {
-  object `a.b` {
-    object c
-  }
+  val refC = c
 }

--- a/output/src/main/scala/fix/GroupedImportsMergeRenames.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeRenames.scala
@@ -1,0 +1,7 @@
+package fix
+
+import fix.MergeImports.Rename1.{a => A, b => B, c, d}
+import fix.MergeImports.Rename2.{a => A, b => B, c}
+import fix.MergeImports.Rename2.{a, b}
+
+object GroupedImportsMergeRenames

--- a/output/src/main/scala/fix/GroupedImportsMergeUnimports.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeUnimports.scala
@@ -1,0 +1,5 @@
+package fix
+
+import fix.MergeImports.Unimport.{b => B, c => _, _}
+
+object GroupedImportsMergeUnimports

--- a/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -1,36 +1,37 @@
 package fix
 
-import fix.GroupedImportsMergeWildcard.P.{b => B, d, _}
-import fix.GroupedImportsMergeWildcard.Q.{b => B, c => _, d, _}
-import fix.GroupedImportsMergeWildcard.R.{a => A, b => B, c, d}
-import fix.GroupedImportsMergeWildcard.S.{a => a1, b => b1, c}
-import fix.GroupedImportsMergeWildcard.S.{a, b}
+import fix.P._
+import fix.P.{b => B}
+import fix.Q.{b => B, c => _, _}
+import fix.R.{a => A, b => B, c, d}
+import fix.S.{a => a1, b => b1, c}
+import fix.S.{a, b}
 
-object GroupedImportsMergeWildcard {
-  object P {
-    val a = ???
-    val b = ???
-    val c = ???
-    val d = ???
-  }
-
-  object Q {
-    val a = ???
-    val b = ???
-    val c = ???
-    val d = ???
-  }
-
-  object R {
-    val a = ???
-    val b = ???
-    val c = ???
-    val d = ???
-  }
-  
-  object S {
-    val a = ???
-    val b = ???
-    val c = ???
-  }
+object P {
+  val a = ???
+  val b = ???
+  val c = ???
+  val d = ???
 }
+
+object Q {
+  val a = ???
+  val b = ???
+  val c = ???
+  val d = ???
+}
+
+object R {
+  val a = ???
+  val b = ???
+  val c = ???
+  val d = ???
+}
+
+object S {
+  val a = ???
+  val b = ???
+  val c = ???
+}
+
+object GroupedImportsMergeWildcard

--- a/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -1,37 +1,7 @@
 package fix
 
-import fix.P._
-import fix.P.{b => B}
-import fix.Q.{b => B, c => _, _}
-import fix.R.{a => A, b => B, c, d}
-import fix.S.{a => a1, b => b1, c}
-import fix.S.{a, b}
-
-object P {
-  val a = ???
-  val b = ???
-  val c = ???
-  val d = ???
-}
-
-object Q {
-  val a = ???
-  val b = ???
-  val c = ???
-  val d = ???
-}
-
-object R {
-  val a = ???
-  val b = ???
-  val c = ???
-  val d = ???
-}
-
-object S {
-  val a = ???
-  val b = ???
-  val c = ???
-}
+import fix.MergeImports.Wildcard1._
+import fix.MergeImports.Wildcard1.{b => B}
+import fix.MergeImports.Wildcard2._
 
 object GroupedImportsMergeWildcard

--- a/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -1,5 +1,36 @@
 package fix
 
-import scala.collection.{mutable, _}
+import fix.GroupedImportsMergeWildcard.P.{b => B, d, _}
+import fix.GroupedImportsMergeWildcard.Q.{b => B, c => _, d, _}
+import fix.GroupedImportsMergeWildcard.R.{a => A, b => B, c, d}
+import fix.GroupedImportsMergeWildcard.S.{a => a1, b => b1, c}
+import fix.GroupedImportsMergeWildcard.S.{a, b}
 
-object GroupedImportsMergeWildcard
+object GroupedImportsMergeWildcard {
+  object P {
+    val a = ???
+    val b = ???
+    val c = ???
+    val d = ???
+  }
+
+  object Q {
+    val a = ???
+    val b = ???
+    val c = ???
+    val d = ???
+  }
+
+  object R {
+    val a = ???
+    val b = ???
+    val c = ???
+    val d = ???
+  }
+  
+  object S {
+    val a = ???
+    val b = ???
+    val c = ???
+  }
+}

--- a/shared/src/main/scala/fix/MergeImports.scala
+++ b/shared/src/main/scala/fix/MergeImports.scala
@@ -1,0 +1,35 @@
+package fix
+
+object MergeImports {
+  object Wildcard1 {
+    object a
+    object b
+    object c
+    object d
+  }
+
+  object Wildcard2 {
+    object a
+    object b
+  }
+
+  object Unimport {
+    object a
+    object b
+    object c
+    object d
+  }
+
+  object Rename1 {
+    object a
+    object b
+    object c
+    object d
+  }
+
+  object Rename2 {
+    object a
+    object b
+    object c
+  }
+}

--- a/shared/src/main/scala/fix/QuotedIdent.scala
+++ b/shared/src/main/scala/fix/QuotedIdent.scala
@@ -1,0 +1,7 @@
+package fix
+
+object QuotedIdent {
+  object `a.b` {
+    object c
+  }
+}


### PR DESCRIPTION
PR #21 was a naive fix for the most common cases. It turned out that there are a bunch of corner cases need to be handled while merging imports with the same prefix. Previously, when `groupedImports` is set to `true`, we simply collect all the import selectors within a group and put them into a single import statement. This is far from enough. Here are some examples:

1.  Unimports:

    ```scala
    import p.{A => _, _}      // (1)
    import p.{B => _, _}      // (2)
    ```

    We cannot simply merge them into

    ```scala
    import p.{A => _, B => _, _}
    ```

    Because (2) cancels (1). The correct result should be:

    ```scala
    import p.{A => _, _}
    ```

1.  Renaming (a simplified real world case I hit in Scalameta):

    ```scala
    import java.util
    import java.{util => ju}
    ```

    This cannot be merged into

    ```scala
    import java.{util, util => ju}
    ```

    Scala simply disallows the same name (`util` here) appearing in the same import statement more than once.

1.  Renaming and wildcard (another simplified real world case in Scalameta):

    ```scala
    import p._
    import p.{A => A1}
    ```

    We cannot merge them into:

    ```scala
    import p.{A => A1, _}
    ```

    Because the original version makes both `A` and `A1` available while the rewritten version only exposes `A1`.

1.  Duplicate imports

    Although redundant, the following snippet is legal:

    ```scala
    import p.A
    import p.A
    ```

    Similar to the above case, we cannot merge them into:

    ```scala
    import p.{A, A}
    ```

This PR:

1.  Reimplements import merging to handle all these cases with new tests
1.  Adds a new `shared` sub-project to host testing source code shared by different test cases in the `input` project.

Tested this PR by running `OrganizeImports` on scalameta/metals master using the following configuration:

```hocon
OrganizeImports {
  expandRelative = false
  groupedImports = Merge
  groups = [
    "re:javax?\\."
    "scala."
    "scala.meta."
    "*"
  ]
  importSelectorsOrder = Keep
  removeUnused = true
}
```