### PR TITLE
Symbols with EmptyPackage as their owner are also fully-qualified

### DIFF
--- a/input/src/main/scala/ExpandRelativeRootPackage.scala
+++ b/input/src/main/scala/ExpandRelativeRootPackage.scala
@@ -1,0 +1,19 @@
+/*
+rules = OrganizeImports
+OrganizeImports.expandRelative = true
+ */
+
+import P._
+import Q.x
+import Q._
+
+object P {
+  object x
+}
+
+object Q {
+  object x
+  object y
+}
+
+object ExpandRelativeRootPackage

--- a/output/src/main/scala/ExpandRelativeRootPackage.scala
+++ b/output/src/main/scala/ExpandRelativeRootPackage.scala
@@ -1,0 +1,14 @@
+import P._
+import Q._
+import Q.x
+
+object P {
+  object x
+}
+
+object Q {
+  object x
+  object y
+}
+
+object ExpandRelativeRootPackage

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -233,8 +233,10 @@ object OrganizeImports {
     }
   }
 
-  private def isFullyQualified(importer: Importer)(implicit doc: SemanticDocument): Boolean =
-    topQualifierOf(importer.ref).symbol.owner == Symbol.RootPackage
+  private def isFullyQualified(importer: Importer)(implicit doc: SemanticDocument): Boolean = {
+    val owner = topQualifierOf(importer.ref).symbol.owner
+    owner.isRootPackage || owner.isEmptyPackage
+  }
 
   private def prettyPrintImportGroup(group: Seq[Importer]): String =
     group


### PR DESCRIPTION
This PR fixes the `_empty_` package issue reported in #17.