### PR TITLE
Explicitly imported names should not be removed while exploding or merging imports

### DIFF
--- a/input/src/main/scala/fix/GroupedImportsExplodeMixed.scala
+++ b/input/src/main/scala/fix/GroupedImportsExplodeMixed.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Explode
+}
+ */
+package fix
+
+import scala.collection.immutable._
+import scala.collection.mutable.{Map, Seq => S, Buffer => _, _}
+
+object GroupedImportsExplodeMixed {
+  val m: Map[Int, Int] = ???
+}

--- a/output/src/main/scala/fix/GroupedImportsExplodeMixed.scala
+++ b/output/src/main/scala/fix/GroupedImportsExplodeMixed.scala
@@ -1,0 +1,10 @@
+package fix
+
+import scala.collection.immutable._
+import scala.collection.mutable.Map
+import scala.collection.mutable.{Buffer => _, _}
+import scala.collection.mutable.{Seq => S}
+
+object GroupedImportsExplodeMixed {
+  val m: Map[Int, Int] = ???
+}

--- a/output/src/main/scala/fix/GroupedImportsMergeUnimports.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeUnimports.scala
@@ -1,5 +1,5 @@
 package fix
 
-import fix.MergeImports.Unimport.{b => B, c => _, _}
+import fix.MergeImports.Unimport.{b => B, c => _, d, _}
 
 object GroupedImportsMergeUnimports

--- a/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeWildcard.scala
@@ -1,7 +1,7 @@
 package fix
 
-import fix.MergeImports.Wildcard1._
+import fix.MergeImports.Wildcard1.{d, _}
 import fix.MergeImports.Wildcard1.{b => B}
-import fix.MergeImports.Wildcard2._
+import fix.MergeImports.Wildcard2.{a, b, _}
 
 object GroupedImportsMergeWildcard

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -325,7 +325,7 @@ object OrganizeImports {
 
   private def explodeImportees(importers: Seq[Importer]): Seq[Importer] =
     importers.flatMap {
-      case Importer(ref, Importees(names, renames, unimports, wildcard @ Some(_))) =>
+      case Importer(ref, Importees(names, renames, unimports, Some(wildcard))) =>
         // When a wildcard exists, all unimports (if any) and the wildcard must appear in the same
         // importer, e.g.:
         //
@@ -336,7 +336,7 @@ object OrganizeImports {
         //   import p.{A => _, B => _, _}
         //   import p.{C => D}
         //   import p.E
-        (names ++ renames).map(i => Importer(ref, i :: Nil)) :+ Importer(ref, unimports ++ wildcard)
+        (names ++ renames).map(i => Importer(ref, i :: Nil)) :+ Importer(ref, unimports :+ wildcard)
 
       case importer =>
         importer.importees map (i => importer.copy(importees = i :: Nil))

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -308,32 +308,24 @@ object OrganizeImports {
           }
 
         val importeesList = (hasWildcard, lastUnimports) match {
-          case (true, _) if renames.isEmpty =>
-            Seq(Importee.Wildcard() :: Nil)
-
           case (true, _) =>
-            Seq(Importee.Wildcard() :: Nil, renames)
-
-          case (false, Some(unimports)) if renamedNames.isEmpty =>
-            Seq(renames ++ unimports :+ Importee.Wildcard())
+            // Unimports are canceled by the wildcard.
+            Seq(renames, names :+ Importee.Wildcard())
 
           case (false, Some(unimports)) =>
-            Seq(renamedNames, renames ++ unimports :+ Importee.Wildcard())
-
-          case (false, None) if renamedNames.isEmpty =>
-            Seq(renames ++ names)
+            Seq(renamedNames, names ++ renames ++ unimports :+ Importee.Wildcard())
 
           case (false, None) =>
-            Seq(renamedNames, renames ++ names)
+            Seq(renamedNames, names ++ renames)
         }
 
-        importeesList map (Importer(ref, _))
+        importeesList filter (_.nonEmpty) map (Importer(ref, _))
     }
   }
 
   private def explodeImportees(importers: Seq[Importer]): Seq[Importer] =
     importers.flatMap {
-      case Importer(ref, Importees(_, renames, unimports, Some(wildcard))) =>
+      case Importer(ref, Importees(names, renames, unimports, wildcard @ Some(_))) =>
         // When a wildcard exists, all unimports (if any) and the wildcard must appear in the same
         // importer, e.g.:
         //
@@ -343,10 +335,8 @@ object OrganizeImports {
         //
         //   import p.{A => _, B => _, _}
         //   import p.{C => D}
-        //
-        // Note that `E` is discarded since it's covered by the wildcard, but the rename `{C => D}`
-        // still needs to be preserved.
-        renames.map(i => Importer(ref, i :: Nil)) :+ Importer(ref, unimports :+ wildcard)
+        //   import p.E
+        (names ++ renames).map(i => Importer(ref, i :: Nil)) :+ Importer(ref, unimports ++ wildcard)
 
       case importer =>
         importer.importees map (i => importer.copy(importees = i :: Nil))


### PR DESCRIPTION
This PR fixes #25.