### PR TITLE
Fix a corner case about quoted identifiers containing curly braces

### DIFF
--- a/input/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
+++ b/input/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
@@ -6,7 +6,6 @@ package fix
 
 import QuotedIdent.`a.b`
 import `a.b`.c
+import `a.b`.`{ d }`
 
-object ExpandRelativeQuotedIdent {
-  val refC = c
-}
+object ExpandRelativeQuotedIdent

--- a/output/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
+++ b/output/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
@@ -1,8 +1,7 @@
 package fix
 
 import fix.QuotedIdent.`a.b`
+import fix.QuotedIdent.`a.b`.`{ d }`
 import fix.QuotedIdent.`a.b`.c
 
-object ExpandRelativeQuotedIdent {
-  val refC = c
-}
+object ExpandRelativeQuotedIdent

--- a/shared/src/main/scala/fix/QuotedIdent.scala
+++ b/shared/src/main/scala/fix/QuotedIdent.scala
@@ -3,5 +3,6 @@ package fix
 object QuotedIdent {
   object `a.b` {
     object c
+    object `{ d }`
   }
 }


### PR DESCRIPTION
Previously, the `fixedImporterSyntax` method uses naive string replacements, which cannot handle quoted identifiers like `` `{ d }` ``. This PR fixes this corner case.