### PR TITLE
Refactoring: do not interwine semantic and syntactic transformations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/target/
+.vscode/
 project/metals.sbt
 project/project/

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -159,9 +159,11 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
   private def expandRelative(importer: Importer)(implicit doc: SemanticDocument): Importer = {
     // NOTE: An `Importer.Ref` instance constructed by `toRef` does NOT contain symbol information
     // since it's not parsed from the source file.
-    def toRef(symbol: Symbol): Term.Ref =
-      if (symbol.owner == Symbol.RootPackage) Term.Name(symbol.displayName)
-      else Term.Select(toRef(symbol.owner), Term.Name(symbol.displayName))
+    def toRef(symbol: Symbol): Term.Ref = {
+      val owner = symbol.owner
+      if (owner.isRootPackage || owner.isEmptyPackage) Term.Name(symbol.displayName)
+      else Term.Select(toRef(owner), Term.Name(symbol.displayName))
+    }
 
     if (!config.expandRelative || isFullyQualified(importer)) importer
     else importer.copy(ref = toRef(importer.ref.symbol.normalized))


### PR DESCRIPTION
Semantic transformations often requires symbol table information (e.g. `expandRelative`), which is only available for AST nodes directly parsed from the source document. On the other hand, some other transformations often builds new AST nodes without symbol table information.

Previously, we interwine these two types of transformations and caused some hacky code path. This PR separate them to simplify things.