### PR TITLE
Implements the SymbolsFirst import sorting order properly

### DIFF
--- a/input/src/main/scala/fix/ImportsOrderSymbolsFirst.scala
+++ b/input/src/main/scala/fix/ImportsOrderSymbolsFirst.scala
@@ -12,4 +12,8 @@ import scala.concurrent._
 import scala.concurrent.duration
 import scala.concurrent.{Promise, Future}
 
+import fix.QuotedIdent.`a.b`.`{ d }`.e
+import fix.QuotedIdent.`a.b`.{c => _, _}
+import fix.QuotedIdent._
+
 object ImportsOrderSymbolsFirst

--- a/output/src/main/scala/fix/ImportsOrderSymbolsFirst.scala
+++ b/output/src/main/scala/fix/ImportsOrderSymbolsFirst.scala
@@ -5,4 +5,8 @@ import scala.concurrent.{Future, Promise}
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.duration
 
+import fix.QuotedIdent._
+import fix.QuotedIdent.`a.b`.{c => _, _}
+import fix.QuotedIdent.`a.b`.`{ d }`.e
+
 object ImportsOrderSymbolsFirst

--- a/shared/src/main/scala/fix/QuotedIdent.scala
+++ b/shared/src/main/scala/fix/QuotedIdent.scala
@@ -3,6 +3,8 @@ package fix
 object QuotedIdent {
   object `a.b` {
     object c
-    object `{ d }`
+    object `{ d }` {
+      object e
+    }
   }
 }


### PR DESCRIPTION
This PR reimplements the `SymbolsFirst` so that we can handle corner cases like (quoted) identifier containing underscores and/or curly braces.