### PR TITLE
Preserve source level formatting if an import is already organized

### DIFF
--- a/input/src/main/scala/fix/AlreadyOrganized.scala
+++ b/input/src/main/scala/fix/AlreadyOrganized.scala
@@ -1,0 +1,17 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Merge
+  importSelectorsOrder = Ascii
+}
+ */
+package fix
+
+import scala.collection.mutable.{
+  ArrayBuffer,
+  Map,
+  Queue,
+  Set
+}
+
+object AlreadyOrganized

--- a/output/src/main/scala/fix/AlreadyOrganized.scala
+++ b/output/src/main/scala/fix/AlreadyOrganized.scala
@@ -1,0 +1,10 @@
+package fix
+
+import scala.collection.mutable.{
+  ArrayBuffer,
+  Map,
+  Queue,
+  Set
+}
+
+object AlreadyOrganized

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -123,12 +123,9 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
           case _                        => importee.pos
         }
 
-      val unusedRemoved = importer.importees filterNot { importee =>
-        unusedImports contains importeePosition(importee)
-      }
-
-      if (unusedRemoved.isEmpty) Nil
-      else importer.copy(importees = unusedRemoved) :: Nil
+      filterImportees(importer) { importee =>
+        !unusedImports.contains(importeePosition(importee))
+      }.toSeq
     }
 
   private def partitionImplicits(
@@ -146,9 +143,9 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
       }.unzip
 
       val noImplicits = importers.flatMap {
-        case importer @ Importer(_, importees) =>
-          val implicitsRemoved = importees.filterNot(i => implicitPositions.contains(i.pos))
-          if (implicitsRemoved.isEmpty) Nil else importer.copy(importees = implicitsRemoved) :: Nil
+        filterImportees(_) { importee =>
+          !implicitPositions.contains(importee.pos)
+        }.toSeq
       }
 
       (implicits, noImplicits)
@@ -226,12 +223,20 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
     val (wildcard, noWildcard) = importer.importees partition (_.is[Importee.Wildcard])
 
     val orderedImportees = config.importSelectorsOrder match {
-      case Ascii        => noWildcard.sortBy(_.syntax)
-      case SymbolsFirst => sortImporteesSymbolsFirst(noWildcard)
-      case Keep         => noWildcard
+      case Ascii        => noWildcard.sortBy(_.syntax) ++ wildcard
+      case SymbolsFirst => sortImporteesSymbolsFirst(noWildcard) ++ wildcard
+      case Keep         => importer.importees
     }
 
-    importer.copy(importees = orderedImportees ++ wildcard)
+    // Checks whether importees of the input importer are already sorted. If yes, we should return
+    // the original importer to preserve the original source level formatting.
+    val alreadySorted =
+      config.importSelectorsOrder == Keep ||
+        (importer.importees corresponds orderedImportees) { (lhs, rhs) =>
+          lhs.syntax == rhs.syntax
+        }
+
+    if (alreadySorted) importer else importer.copy(importees = orderedImportees)
   }
 
   // Returns the index of the group to which the given importer belongs.
@@ -319,6 +324,11 @@ object OrganizeImports {
 
   private def mergeImporters(importers: Seq[Importer]): Seq[Importer] = {
     importers.groupBy(_.ref.syntax).values.toSeq.flatMap {
+      case importer :: Nil =>
+        // If this group has only one importer, returns it as is to preserve the original source
+        // level formatting.
+        importer :: Nil
+
       case group @ (Importer(ref, _) :: _) =>
         val hasWildcard = group map (_.importees) exists {
           case Importees(_, _, Nil, Some(_)) => true
@@ -337,7 +347,7 @@ object OrganizeImports {
         //
         //   import p.{A => _, _} // Import everything under `p` except `A`.
         //   import p.{A => _}    // Legal, but meaningless.
-        val lastUnimports = group.reverse map (_.importees) collectFirst {
+        val lastUnimportsWildcard = group.reverse map (_.importees) collectFirst {
           case Importees(_, _, unimports @ (_ :: _), Some(_)) => unimports
         }
 
@@ -379,7 +389,7 @@ object OrganizeImports {
               }
           }
 
-        val importeesList = (hasWildcard, lastUnimports) match {
+        val importeesList = (hasWildcard, lastUnimportsWildcard) match {
           case (true, _) =>
             // A few things to note in this case:
             //
@@ -438,6 +448,10 @@ object OrganizeImports {
 
   private def explodeImportees(importers: Seq[Importer]): Seq[Importer] =
     importers.flatMap {
+      case importer @ Importer(_, _ :: Nil) =>
+        // If the importer has exactly one importee, leave it untouched.
+        importer :: Nil
+
       case Importer(ref, Importees(names, renames, unimports, Some(wildcard))) =>
         // When a wildcard exists, all unimports (if any) and the wildcard must appear in the same
         // importer, e.g.:
@@ -508,5 +522,16 @@ object OrganizeImports {
         }
 
     Patch.addLeft(token, indentedOutput mkString "\n")
+  }
+
+  // Returns an importer with all the importees selected from the input importer that satisfy a
+  // predicate. If all the importees are selected, the input importer instance is returned to
+  // preserve the original source level formatting. If none of the importees are selected, returns
+  // a `None`.
+  private def filterImportees(importer: Importer)(f: Importee => Boolean): Option[Importer] = {
+    val filtered = importer.importees filter f
+    if (filtered.length == importer.importees.length) Some(importer)
+    else if (filtered.isEmpty) None
+    else Some(importer.copy(importees = filtered))
   }
 }

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -449,7 +449,8 @@ object OrganizeImports {
   private def explodeImportees(importers: Seq[Importer]): Seq[Importer] =
     importers.flatMap {
       case importer @ Importer(_, _ :: Nil) =>
-        // If the importer has exactly one importee, leave it untouched.
+        // If the importer has exactly one importee, returns it as is to preserve the original
+        // source level formatting.
         importer :: Nil
 
       case Importer(ref, Importees(names, renames, unimports, Some(wildcard))) =>


### PR DESCRIPTION
This PR fixes issue #43.

Before this PR, in various cases, although an import is already organized according to the configuration, `OrganizeImports` still builds a new `Importer` instance that is semantically equivalent to the original one and then pretty print it to produce the end result. The problem of this approach is that we lost the original source level formatting. For example, with the following configuration:

```hocon
rules = [OrganizeImports]

OrganizeImports {
  importSelectorsOrder = Ascii
  groupedImports = Merge
}
```

The following import is already organized:

```scala
import scala.collection.mutable.{
  ArrayBuffer,
  Map,
  Queue,
  Set
}
```

Yet, it is rewritten into:

```scala
import scala.collection.mutable.{ArrayBuffer, Map, Queue, Set}
```

This change is unnecessary and breaks linting.

This PR fixes this issue by explicitly returning the original `Importer` instance (which preserves the original source level formatting) when an `Importer` is not transformed in each rewriting step.