### PR TITLE
Use Tree.toString to pretty-print importers

### DIFF
--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -282,7 +282,11 @@ object OrganizeImports {
   // imports, i.e., "import a.{ b, c }" instead of "import a.{b, c}". Unfortunately, this behavior
   // cannot be overriden. This function removes the unwanted spaces as a workaround.
   private def fixedImporterSyntax(importer: Importer): String = {
-    val syntax = importer.syntax
+    // If the importer originates from the parser, `Tree.toString` returns the original source text
+    // being parsed, and therefore preserves the original source level formatting. If the importer
+    // does not originates from the parser, `Tree.toString` pretty-prints it using the Scala 2.11
+    // dialect, which is good enough for imports.
+    val syntax = importer.toString
 
     // NOTE: We need to check whether the input importer is curly braced first and then replace the
     // first "{ " and the last " }" if any. Naive string replacements are not sufficient, e.g., a


### PR DESCRIPTION
PR #44 doesn't work for Scala versions other than Scala 2.12. This is because `OrganizeImports` calls `importer.syntax` to pretty-print an import expression. Internally, the `syntax` method accepts an implicit `scala.meta.Dialect` parameter. While pretty-printing, the `syntax` method checks two things:

1. Whether this AST node originates directly from the parser.
2. Whether the Scala dialect of the original source being parsed conforms to the implicit dialect.

When both conditions are true, it simply returns the original source text being parsed. Otherwise, it pretty-prints the AST node using the implicit dialect.

For a project written in Scala 2.13, condition 2 doesn't hold and we lose the original source level formatting, and further breaks linting as described in issue #43.

This PR fixes this issue by resorting to `Tree.toString`, which either returns the original source text when the importer originates from the parser or pretty-print the importer using the Scala 2.11 dialect, which is good enough in most cases, including pretty-printing import statements.