### PR TITLE
remove non-global unused imports

### DIFF
--- a/inputUnusedImports/src/main/scala/fix/RemoveUnusedLocal.scala
+++ b/inputUnusedImports/src/main/scala/fix/RemoveUnusedLocal.scala
@@ -1,0 +1,18 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groups = ["re:javax?\\.", "scala.", "*"]
+  removeUnused = true
+}
+ */
+package fix
+
+import scala.collection.mutable.{ArrayBuffer, Buffer}
+
+object RemoveUnusedLocal {
+  import java.time.Clock
+  import java.lang.{Long => JLong, Double => JDouble}
+
+  val buffer: ArrayBuffer[Int] = ArrayBuffer.empty[Int]
+  val long: JLong = JLong.parseLong("0")
+}

--- a/output/src/main/scala/fix/RemoveUnusedLocal.scala
+++ b/output/src/main/scala/fix/RemoveUnusedLocal.scala
@@ -1,0 +1,10 @@
+package fix
+
+import scala.collection.mutable.ArrayBuffer
+
+object RemoveUnusedLocal {
+  import java.lang.{Long => JLong}
+
+  val buffer: ArrayBuffer[Int] = ArrayBuffer.empty[Int]
+  val long: JLong = JLong.parseLong("0")
+}


### PR DESCRIPTION
Moving away from the built-in `RemoveUnused`, I realized that `OrganizeImports` only covered global imports. If this can't be merged for some reason, I think the `README` should explicitly mention this obstacle for migrating.

Thanks for the project!