### PR TITLE
Fix unimports handling while merging imports

### DIFF
--- a/input/src/main/scala/fix/GroupedImportsMergeUnimports.scala
+++ b/input/src/main/scala/fix/GroupedImportsMergeUnimports.scala
@@ -7,9 +7,14 @@ OrganizeImports {
  */
 package fix
 
-import fix.MergeImports.Unimport.{a => _, _}
-import fix.MergeImports.Unimport.{b => B}
-import fix.MergeImports.Unimport.{c => _, _}
-import fix.MergeImports.Unimport.d
+import fix.MergeImports.Unimport1.{a => _, _}
+import fix.MergeImports.Unimport1.{b => B}
+import fix.MergeImports.Unimport1.{c => _, _}
+import fix.MergeImports.Unimport1.d
+
+import fix.MergeImports.Unimport2.{a => _}
+import fix.MergeImports.Unimport2.{b => _}
+import fix.MergeImports.Unimport2.{c => C}
+import fix.MergeImports.Unimport2.d
 
 object GroupedImportsMergeUnimports

--- a/output/src/main/scala/fix/GroupedImportsMergeUnimports.scala
+++ b/output/src/main/scala/fix/GroupedImportsMergeUnimports.scala
@@ -1,5 +1,6 @@
 package fix
 
-import fix.MergeImports.Unimport.{b => B, c => _, d, _}
+import fix.MergeImports.Unimport1.{b => B, c => _, d, _}
+import fix.MergeImports.Unimport2.{a => _, b => _, c => C, d}
 
 object GroupedImportsMergeUnimports

--- a/shared/src/main/scala/fix/MergeImports.scala
+++ b/shared/src/main/scala/fix/MergeImports.scala
@@ -13,7 +13,14 @@ object MergeImports {
     object b
   }
 
-  object Unimport {
+  object Unimport1 {
+    object a
+    object b
+    object c
+    object d
+  }
+
+  object Unimport2 {
     object a
     object b
     object c


### PR DESCRIPTION
Before this PR, `OrganizeImports` does not handle unimports correctly when merging import statements. Somehow, I believed that unimports without an accompanying wildcard is meaningless. Turned out that it was because I was testing this using `scala.collection.{Seq => _}`, which doesn't work because `Seq` is also imported in `scala.Predef`.

This PR fixes wrong behaviors backed by this wrong assumption.