### PR TITLE
importsOrder: correct comparison with IntelliJ in doc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -666,9 +666,9 @@ Specifies the order of import statements within import groups defined by the <<g
 
 Enum: `Ascii | SymbolsFirst | Keep`
 
-`Ascii`:: Sort import statements by ASCII codes.
+`Ascii`:: Sort import statements by ASCII codes. This is the default sorting order that the IntelliJ IDEA Scala import optimizer picks ("lexicographically" option).
 
-`SymbolsFirst`:: Put wildcard imports and grouped imports with braces first, otherwise same as `Ascii`. This is also the sorting order the IntelliJ IDEA Scala import opitimizer picks.
+`SymbolsFirst`:: Put wildcard imports and grouped imports with braces first, otherwise same as `Ascii`. This replicates IntelliJ IDEA Scala's "scalastyle consistent" option.
 
 `Keep`:: Keep the original order.
 


### PR DESCRIPTION
I am challenging https://github.com/liancheng/scalafix-organize-imports/issues/20#issuecomment-619463169 as this is the default I have on my IntelliJ 2020.1 when starting a new Scala (sbt) project

![idea](https://user-images.githubusercontent.com/349077/82264231-cccd3000-9964-11ea-8b65-1809fcc464f1.png)

This is also the behavior I see on my sbt projects: to match the default IntelliJ order, I need `Ascii`.

I haven't been able to find a [test case](https://github.com/JetBrains/intellij-scala/tree/3922c067647f6549a218ebec6e9072a3dc243fd4/scala/scala-impl/testdata/optimize/simple) describing how the default/lexciograpically behaves with regard to braces and wildcards, but the ["scalastyle consistent" mode](https://github.com/JetBrains/intellij-scala/blob/3922c067647f6549a218ebec6e9072a3dc243fd4/scala/scala-impl/src/org/jetbrains/plugins/scala/editor/importOptimizer/ScalastyleSettings.scala#L13) looks like the `SymbolsFirst` considering https://github.com/scalastyle/scalastyle/blob/5c4bb3e1d6b7666c4546bbbd10c4d503455bbc9e/src/test/scala/org/scalastyle/scalariform/ImportsCheckerTest.scala#L217-L218.