### PR TITLE
Cross-build to 2.13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
         run: sbt scalafmtCheckAll "rules/scalafix --check"
 
       - name: Test
-        run: sbt coverage tests/test rules/coverageReport
+        run: sbt +coverage +tests/test +rules/coverageReport
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
         run: sbt scalafmtCheckAll "rules/scalafix --check"
 
       - name: Test
-        run: sbt +coverage +tests/test +rules/coverageReport
+        run: sbt coverage +tests/test +rules/coverageReport
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: olafurpg/setup-scala@v2
       - uses: olafurpg/setup-gpg@v2
       - name: Publish ${{ github.ref }}
-        run: sbt scalafmtCheck "rules/scalafix --check" test ci-release
+        run: sbt scalafmtCheck "rules/scalafix --check" +test ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,8 @@ inThisBuild(
     dependencyOverrides ++= List(
       "org.scala-lang.modules" %% "scala-xml" % "1.2.0",
       "org.slf4j" % "slf4j-api" % "1.7.25",
-      "com.lihaoyi" %% "sourcecode" % "0.2.1"
+      "com.lihaoyi" %% "sourcecode" % "0.2.1",
+      "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.6"
     ),
     addCompilerPlugin(scalafixSemanticdb),
     scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.3.1-RC2",

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,9 @@ inThisBuild(
       )
     ),
     scalaVersion := v.scala212,
+    crossScalaVersions := List(v.scala212, v.scala213),
     scalacOptions ++= List(
+      "-deprecation",
       "-Yrangepos",
       "-P:semanticdb:synthetics:on"
     ),

--- a/rules/src/main/scala/fix/OrganizeImportsConfig.scala
+++ b/rules/src/main/scala/fix/OrganizeImportsConfig.scala
@@ -14,9 +14,9 @@ object ImportsOrder {
   case object Keep extends ImportsOrder
 
   implicit def reader: ConfDecoder[ImportsOrder] =
-    ReaderUtil.fromMap {
-      List(Ascii, SymbolsFirst, Keep) groupBy (_.toString) mapValues (_.head)
-    }
+    ReaderUtil.fromMap(
+      (List(Ascii, SymbolsFirst, Keep) map (v => v.toString -> v)).toMap
+    )
 }
 
 sealed trait ImportSelectorsOrder
@@ -28,7 +28,7 @@ object ImportSelectorsOrder {
 
   implicit def reader: ConfDecoder[ImportSelectorsOrder] =
     ReaderUtil.fromMap {
-      List(Ascii, SymbolsFirst, Keep) groupBy (_.toString) mapValues (_.head)
+      (List(Ascii, SymbolsFirst, Keep) map (v => v.toString -> v)).toMap
     }
 }
 
@@ -41,7 +41,7 @@ object GroupedImports {
 
   implicit def reader: ConfDecoder[GroupedImports] =
     ReaderUtil.fromMap {
-      List(Merge, Explode, Keep) groupBy (_.toString) mapValues (_.head)
+      (List(Merge, Explode, Keep) map (v => v.toString -> v)).toMap
     }
 }
 


### PR DESCRIPTION
`sbt-scalafix` users will soon be able to use _2.13 rules (although the default will remain _2.12 for a while), see https://github.com/scalacenter/scalafix/issues/1108