### PR TITLE
allow -Xlint in OrganizeImports.removeUnused

### DIFF
--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -54,7 +54,10 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
     config.conf.getOrElse("OrganizeImports")(OrganizeImportsConfig()) andThen { conf =>
       val hasWarnUnused = {
         val warnUnusedPrefix = Set("-Wunused", "-Ywarn-unused")
-        config.scalacOptions exists { option => warnUnusedPrefix exists option.startsWith }
+        val warnUnusedString = Set("-Xlint", "-Xlint:unused")
+        config.scalacOptions exists { option =>
+          (warnUnusedPrefix exists option.startsWith) || (warnUnusedString apply option)
+        }
       }
 
       if (!conf.removeUnused || hasWarnUnused)
@@ -63,8 +66,8 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
         Configured.error(
           "The Scala compiler option \"-Ywarn-unused\" is required to use OrganizeImports with"
             + " \"OrganizeImports.removeUnused\" set to true. To fix this problem, update your"
-            + " build to use at least one Scala compiler option that starts with -Ywarn-unused"
-            + " or -Wunused (2.13 only)"
+            + " build to use at least one Scala compiler option like -Ywarn-unused,"
+            + " -Xlint:unused (2.12.2 or above) or -Wunused (2.13 only)"
         )
     }
 


### PR DESCRIPTION
Thank you for creating an awesome Scalafix rule!
I'm trying OrganizeImports rule in my personal project and so far it works great.

Recently I sent a PullRequest to Scalafix RemoveUnused rule to respect `-Xlint` and `-Xlint:unused` scalacOptions, and it has been merged.

https://github.com/scalacenter/scalafix/pull/1163

Since OrganizeImports.removeUnused function comes from RemoveUnused rule, I'd think it's nice to keep compatibilities. So please let me send this PullRequest.