### PR TITLE
Be explicit that names with multiple aliases in the same source file is not supported while merging imports

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -79,7 +79,7 @@ When the number of imported names exceeds a certain threshold, coalesce them int
 
 [CAUTION]
 ====
-Having this feature in `OrganizeImports` is mostly for feature parity with the IntelliJ IDEA Scala import optimizer, but coalescing grouped import selectors into a wildcard import may introduce _compilation errors_! 
+Having this feature in `OrganizeImports` is mostly for feature parity with the IntelliJ IDEA Scala import optimizer, but coalescing grouped import selectors into a wildcard import may introduce _compilation errors_!
 
 Here is an example to illustrate the risk. The following snippet compiles successfully:
 
@@ -348,7 +348,69 @@ Enum: `Explode | Merge | Keep`
 
 `Explode`:: Explode grouped imports into separate import statements.
 
-`Merge`:: Merge imports sharing the same prefix into a single grouped import statement.
+`Merge`::
++
+--
+Merge imports sharing the same prefix into a single grouped import statement.
+
+[IMPORTANT]
+====
+Scala allows a name to be renamed to multiple aliases within a single source file, which makes merging import statements tricky. For example:
+
+[source,scala]
+----
+import java.lang.{Double => JDouble}
+import java.lang.{Double => JavaDouble}
+import java.lang.Integer
+----
+
+The above three imports can be merged into:
+
+[source,scala]
+----
+import java.lang.{Double => JDouble}
+import java.lang.{Double => JavaDouble, Integer}
+----
+
+but not:
+
+[source,scala]
+----
+import java.lang.{Double => JDouble, Double => JavaDouble, Integer}
+----
+
+because Scala disallow a name (in this case, `Double`) to appear in one import multiple times.
+
+Here's a more complicated example:
+
+[source,scala]
+----
+import p.{A => A1}
+import p.{A => A2}
+import p.{A => A3}
+
+import p.{B => B1}
+import p.{B => B2}
+
+import p.{C => C1}
+import p.{C => C2}
+import p.{C => C3}
+import p.{C => C4}
+----
+
+While merging these imports, we may want to "bin-pack" them to minimize the number of the result import statements:
+
+[source,scala]
+----
+import p.{A => A1, B => B1, C => C1}
+import p.{A => A2, B => B2, C => C2}
+import p.{A => A3, C3 => C3}
+import p.{C => C4}
+----
+
+On the other hand, renaming a name to multiple aliases in the same source file is rarely a practical need. Therefore, `OrganizeImports` does not support this when `groupedImports` is set to `Merge` to avoid the extra complexity. (Please note that the IntelliJ IDEA Scala import optimizer does not support this case either.)
+====
+--
 
 `Keep`:: Leave grouped imports and imports sharing the same prefix untouched.
 

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -19,7 +19,6 @@ import scala.util.matching.Regex
 
 import metaconfig.Configured
 import scalafix.lint.Diagnostic
-import scalafix.lint.LintSeverity
 import scalafix.patch.Patch
 import scalafix.v1.Configuration
 import scalafix.v1.Rule
@@ -29,17 +28,6 @@ import scalafix.v1.SemanticRule
 import scalafix.v1.Symbol
 import scalafix.v1.SymbolInformation
 import scalafix.v1.XtensionTreeScalafix
-
-case class ImporterSymbolNotFound(ref: Term.Name) extends Diagnostic {
-  override def position: meta.Position = ref.pos
-
-  override def message: String =
-    s"Could not determine whether '${ref.syntax}' is fully-qualified because the symbol" +
-      " information is missing. We will continue processing assuming that it is fully-qualified." +
-      " Please check whether the corresponding .semanticdb file is properly generated."
-
-  override def severity: LintSeverity = LintSeverity.Warning
-}
 
 class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("OrganizeImports") {
   import OrganizeImports._
@@ -332,6 +320,147 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
     }
   }
 
+  private def mergeImporters(importers: Seq[Importer]): Seq[Importer] =
+    importers.groupBy(_.ref.syntax).values.toSeq.flatMap {
+      case importer :: Nil =>
+        // If this group has only one importer, returns it as is to preserve the original source
+        // level formatting.
+        importer :: Nil
+
+      case group @ Importer(ref, _) :: _ =>
+        val importeeLists = group map (_.importees)
+
+        val hasWildcard = importeeLists exists {
+          case Importees(_, _, Nil, Some(_)) => true
+          case _                             => false
+        }
+
+        // Collects the last set of unimports with a wildcard, if any. It cancels all previous
+        // unimports. E.g.:
+        //
+        //   import p.{A => _}
+        //   import p.{B => _, _}
+        //   import p.{C => _, _}
+        //
+        // Only `C` is unimported. `A` and `B` are still available.
+        //
+        // TODO: Shall we issue a warning here as using order-sensitive imports is a bad practice?
+        val lastUnimportsWithWildcard = importeeLists.reverse collectFirst {
+          case Importees(_, _, unimports @ _ :: _, Some(_)) => unimports
+        }
+
+        // Collects all unimports without an accompanying wildcard.
+        val allUnimports = importeeLists.collect {
+          case Importees(_, _, unimports, None) => unimports
+        }.flatten
+
+        val allImportees = group flatMap (_.importees)
+
+        // Here we assume that a name is renamed at most once within a single source file, which is
+        // true in most cases.
+        //
+        // Note that the IntelliJ IDEA Scala import optimizer does not handle this case properly
+        // either. If a name is renamed more than once, it only keeps one of the renames in the
+        // result and may break compilation (unless other renames are not actually referenced).
+        val renames = allImportees
+          .filter(_.is[Importee.Rename])
+          .map { case rename: Importee.Rename => rename }
+          .groupBy(_.name.value)
+          .mapValues {
+            case rename :: Nil => rename
+            case renames @ (head @ Importee.Rename(from, _)) :: _ =>
+              diagnostics += RenamedMultipleTimes(from, renames)
+              head
+          }
+          .values
+          .toList
+
+        // Collects distinct explicitly imported names, and filters out those that are also renamed.
+        // If an explicitly imported name is also renamed, both the original name and the new name
+        // are available. This implies that both of them must be preserved in the merged result, but
+        // in two separate import statements (Scala only allows a name to appear in an import at
+        // most once). E.g.:
+        //
+        //   import p.A
+        //   import p.{A => A1}
+        //   import p.B
+        //   import p.{B => B1}
+        //
+        // The above snippet should be rewritten into:
+        //
+        //   import p.{A, B}
+        //   import p.{A => A1, B => B1}
+        val (renamedImportedNames, importedNames) = {
+          val renamedNames = renames.map {
+            case Importee.Rename(Name(from), _) => from
+          }.toSet
+
+          allImportees
+            .filter(_.is[Importee.Name])
+            .groupBy { case Importee.Name(Name(name)) => name }
+            .map { case (_, importees) => importees.head }
+            .toList
+            .partition { case Importee.Name(Name(name)) => renamedNames contains name }
+        }
+
+        val wildcard = Importee.Wildcard()
+
+        val importeesList = (hasWildcard, lastUnimportsWithWildcard) match {
+          case (true, _) =>
+            // A few things to note in this case:
+            //
+            // 1. Unimports are discarded because they are canceled by the wildcard.
+            //
+            // 2. Explicitly imported names can NOT be discarded even though they seem to be covered
+            //    by the wildcard. This is because explicitly imported names have higher precedence
+            //    than names imported via a wildcard. Discarding them may introduce ambiguity in
+            //    some cases. E.g.:
+            //
+            //      import scala.collection.immutable._
+            //      import scala.collection.mutable._
+            //      import scala.collection.mutable.Set
+            //
+            //      object Main { val s: Set[Int] = ??? }
+            //
+            //    The type of `Main.s` above is unambiguous because `mutable.Set` is explicitly
+            //    imported, and has higher precedence than `immutable.Set`, which is made available
+            //    via a wildcard. In this case, the imports should be merged into:
+            //
+            //      import scala.collection.immutable._
+            //      import scala.collection.mutable.{Set, _}
+            //
+            //    rather than
+            //
+            //      import scala.collection.immutable._
+            //      import scala.collection.mutable._
+            //
+            //    Otherwise, the type of `Main.s` becomes ambiguous and a compilation error is
+            //    introduced.
+            //
+            // 3. Renames must be moved into a separate import statement to make sure that the
+            //    original names made available by the wildcard are still preserved. E.g.:
+            //
+            //      import p._
+            //      import p.{A => A1}
+            //
+            //    The above imports cannot be merged into
+            //
+            //      import p.{A => A1, _}
+            //
+            //    Otherwise, the original name `A` is no longer available.
+            Seq(renames, importedNames :+ wildcard)
+
+          case (false, Some(unimports)) =>
+            // A wildcard must be appended for unimports.
+            Seq(renamedImportedNames, importedNames ++ renames ++ unimports :+ wildcard)
+
+          case (false, None) =>
+            Seq(renamedImportedNames, importedNames ++ renames ++ allUnimports)
+        }
+
+        importeesList filter (_.nonEmpty) map (Importer(ref, _))
+    }
+
   private def sortImportersSymbolsFirst(importers: Seq[Importer]): Seq[Importer] =
     importers.sortBy { importer =>
       // See the comment marked with "Issue #84" for why a `.copy()` is needed.
@@ -481,136 +610,6 @@ object OrganizeImports {
 
     List(symbols, lowerCases, upperCases) flatMap (_ sortBy (_.syntax))
   }
-
-  private def mergeImporters(importers: Seq[Importer]): Seq[Importer] =
-    importers.groupBy(_.ref.syntax).values.toSeq.flatMap {
-      case importer :: Nil =>
-        // If this group has only one importer, returns it as is to preserve the original source
-        // level formatting.
-        importer :: Nil
-
-      case group @ Importer(ref, _) :: _ =>
-        val importeeLists = group map (_.importees)
-
-        val hasWildcard = importeeLists exists {
-          case Importees(_, _, Nil, Some(_)) => true
-          case _                             => false
-        }
-
-        // Collects the last set of unimports with a wildcard, if any. It cancels all previous
-        // unimports. E.g.:
-        //
-        //   import p.{A => _}
-        //   import p.{B => _, _}
-        //   import p.{C => _, _}
-        //
-        // Only `C` is unimported. `A` and `B` are still available.
-        //
-        // TODO: Shall we issue a warning here as using order-sensitive imports is a bad practice?
-        val lastUnimportsWildcard = importeeLists.reverse collectFirst {
-          case Importees(_, _, unimports @ _ :: _, Some(_)) => unimports
-        }
-
-        // Collects all unimports without an accompanying wildcard.
-        val allUnimports = importeeLists.collect {
-          case Importees(_, _, unimports, None) => unimports
-        }.flatten
-
-        val allImportees = group flatMap (_.importees)
-
-        val allRenames = allImportees
-          .filter(_.is[Importee.Rename])
-          .groupBy { case Importee.Rename(Name(name), _) => name }
-          // TODO: Is there a bug? Seems that we should preserve the last Rename since it shadows
-          // all the previous ones?
-          .map { case (_, importees) => importees.head }
-          .toList
-
-        // Collects distinct explicitly imported names, and filters out those that are also renamed.
-        // If an explicitly imported name is also renamed, both the original name and the new name
-        // are available. This implies that both of them must be preserved in the merged result, but
-        // in two separate import statements, since Scala disallows a name to appear more than once
-        // in a single import statement. E.g.:
-        //
-        //   import p.A
-        //   import p.{A => A1}
-        //   import p.B
-        //   import p.{B => B1}
-        //
-        // The above snippet should be rewritten into:
-        //
-        //   import p.{A, B}
-        //   import p.{A => A1, B => B1}
-        val (renamedNames, importedNames) = allImportees
-          .filter(_.is[Importee.Name])
-          .groupBy { case Importee.Name(Name(name)) => name }
-          .map { case (_, importees) => importees.head }
-          .toList
-          .partition {
-            case Importee.Name(Name(name)) =>
-              allRenames exists {
-                case Importee.Rename(Name(`name`), _) => true
-                case _                                => false
-              }
-          }
-
-        val wildcard = Importee.Wildcard()
-
-        val importeesList = (hasWildcard, lastUnimportsWildcard) match {
-          case (true, _) =>
-            // A few things to note in this case:
-            //
-            // 1. Unimports are discarded because they are canceled by the wildcard.
-            //
-            // 2. Explicitly imported names can NOT be discarded even though they seem to be covered
-            //    by the wildcard. This is because explicitly imported names have higher precedence
-            //    than names imported via a wildcard. Discarding them may introduce ambiguity in
-            //    some cases. E.g.:
-            //
-            //      import scala.collection.immutable._
-            //      import scala.collection.mutable._
-            //      import scala.collection.mutable.Set
-            //
-            //      object Main { val s: Set[Int] = ??? }
-            //
-            //    The type of `Main.s` above is unambiguous because `mutable.Set` is explicitly
-            //    imported, and has higher precedence than `immutable.Set`, which is made available
-            //    via a wildcard. In this case, the imports should be merged into:
-            //
-            //      import scala.collection.immutable._
-            //      import scala.collection.mutable.{Set, _}
-            //
-            //    rather than
-            //
-            //      import scala.collection.immutable._
-            //      import scala.collection.mutable._
-            //
-            //    Otherwise, the type of `Main.s` becomes ambiguous and a compilation error is
-            //    introduced.
-            //
-            // 3. Renames must be moved into a separate import statement to make sure that the
-            //    original names made available by the wildcard are still preserved. E.g.:
-            //
-            //      import p._
-            //      import p.{A => A1}
-            //
-            //    The above imports cannot be merged into
-            //
-            //      import p.{A => A1, _}
-            //
-            //    Otherwise, the original name `A` is no longer available.
-            Seq(allRenames, importedNames :+ wildcard)
-
-          case (false, Some(unimports)) =>
-            // A wildcard must be appended for unimports.
-            Seq(renamedNames, importedNames ++ allRenames ++ unimports :+ wildcard)
-
-          case (false, None) =>
-            Seq(renamedNames, importedNames ++ allRenames ++ allUnimports)
-        }
-
-        importeesList filter (_.nonEmpty) map (Importer(ref, _))
-    }
 
   private def explodeImportees(importers: Seq[Importer]): Seq[Importer] =
     importers flatMap {

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -369,7 +369,7 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
           .mapValues {
             case rename :: Nil => rename
             case renames @ (head @ Importee.Rename(from, _)) :: _ =>
-              diagnostics += RenamedMultipleTimes(from, renames)
+              diagnostics += TooManyAliases(from, renames)
               head
           }
           .values

--- a/rules/src/main/scala/fix/diagnostics.scala
+++ b/rules/src/main/scala/fix/diagnostics.scala
@@ -18,7 +18,7 @@ case class ImporterSymbolNotFound(ref: Term.Name) extends Diagnostic {
   override def severity: LintSeverity = LintSeverity.Warning
 }
 
-case class RenamedMultipleTimes(name: Name, renames: Seq[Importee.Rename]) extends Diagnostic {
+case class TooManyAliases(name: Name, renames: Seq[Importee.Rename]) extends Diagnostic {
   assert(renames.length > 1)
 
   override def position: meta.Position = name.pos
@@ -34,7 +34,7 @@ case class RenamedMultipleTimes(name: Name, renames: Seq[Importee.Rename]) exten
       case init :+ last        => init mkString ("", ", ", s", and $last")
     }
 
-    s"When 'OrganizeImports.groupedImports' is set to `Merge`, renaming a name to multiple" +
+    s"When `OrganizeImports.groupedImports` is set to `Merge`, renaming a name to multiple" +
       s" aliases within the same source file is not supported. In this case, '${name.value}' is" +
       s" renamed to $aliasList."
   }

--- a/rules/src/main/scala/fix/diagnostics.scala
+++ b/rules/src/main/scala/fix/diagnostics.scala
@@ -1,0 +1,43 @@
+package fix
+
+import scala.meta.Importee
+import scala.meta.Name
+import scala.meta.Term
+
+import scalafix.lint.Diagnostic
+import scalafix.lint.LintSeverity
+
+case class ImporterSymbolNotFound(ref: Term.Name) extends Diagnostic {
+  override def position: meta.Position = ref.pos
+
+  override def message: String =
+    s"Could not determine whether '${ref.syntax}' is fully-qualified because the symbol" +
+      " information is missing. We will continue processing assuming that it is fully-qualified." +
+      " Please check whether the corresponding .semanticdb file is properly generated."
+
+  override def severity: LintSeverity = LintSeverity.Warning
+}
+
+case class RenamedMultipleTimes(name: Name, renames: Seq[Importee.Rename]) extends Diagnostic {
+  assert(renames.length > 1)
+
+  override def position: meta.Position = name.pos
+
+  override def message: String = {
+    val aliases = renames
+      .map { case Importee.Rename(_, Name(alias)) => alias }
+      .sorted
+      .map("'" + _ + "'")
+
+    val aliasList = aliases match {
+      case head :: last :: Nil => s"$head and $last"
+      case init :+ last        => init mkString ("", ", ", s", and $last")
+    }
+
+    s"When 'OrganizeImports.groupedImports' is set to `Merge`, renaming a name to multiple" +
+      s" aliases within the same source file is not supported. In this case, '${name.value}' is" +
+      s" renamed to $aliasList."
+  }
+
+  override def severity: LintSeverity = LintSeverity.Error
+}


### PR DESCRIPTION
This PR addresses issue #91.