### PR TITLE
Preserve the original source-level formatting when possible after merging imports

### DIFF
--- a/shared/src/main/scala/fix/MergeImports.scala
+++ b/shared/src/main/scala/fix/MergeImports.scala
@@ -45,4 +45,16 @@ object MergeImports {
     object b
     object c
   }
+
+  object FormatPreserving {
+    object g1 {
+      object a
+      object b
+    }
+
+    object g2 {
+      object c
+      object d
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes issue #127.