### PR TITLE
Use new IntelliJ import order

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -95,7 +95,7 @@ OrganizeImports {
   expandRelative = false
   groupExplicitlyImportedImplicitsSeparately = false
   groupedImports = Explode
-  groups = ["re:javax?\\.", "scala.", "*"]
+  groups = ["*", "re:(javax?|scala)\\."]
   importSelectorsOrder = Ascii
   importsOrder = Ascii
   removeUnused = true
@@ -673,9 +673,8 @@ OrganizeImports.groups = ["re:javax?\\.", "scala."]
 [source,hocon]
 ----
 [
-  "re:javax?\\."
-  "scala."
   "*"
+  "re:(javax?|scala)\\."
 ]
 ----
 

--- a/output/src/main/scala/fix/ExpandRelativeRootPackage.scala
+++ b/output/src/main/scala/fix/ExpandRelativeRootPackage.scala
@@ -1,9 +1,9 @@
 package fix
 
-import scala.util.control
-import scala.util.control.NonFatal
-
 import _root_.scala.collection.mutable.ArrayBuffer
 import _root_.scala.util
+
+import scala.util.control
+import scala.util.control.NonFatal
 
 object ExpandRelativeRootPackage

--- a/output/src/main/scala/fix/ExplicitlyImportedImplicits.scala
+++ b/output/src/main/scala/fix/ExplicitlyImportedImplicits.scala
@@ -1,9 +1,9 @@
 package fix
 
-import scala.concurrent.ExecutionContext
-
 import fix.Implicits.a.nonImplicit
 import fix.Implicits.b._
+
+import scala.concurrent.ExecutionContext
 
 import ExecutionContext.Implicits.global
 import fix.Implicits.a.intImplicit

--- a/output/src/main/scala/fix/GlobalImportsOnly.scala
+++ b/output/src/main/scala/fix/GlobalImportsOnly.scala
@@ -2,7 +2,6 @@ package fix
 
 import java.sql.DriverManager
 import java.time.Clock
-
 import scala.collection.mutable
 import scala.concurrent.duration.Duration
 

--- a/output/src/main/scala/fix/ImportsOrderKeep.scala
+++ b/output/src/main/scala/fix/ImportsOrderKeep.scala
@@ -1,12 +1,12 @@
 package fix
 
+import fix.QuotedIdent.`a.b`.`{ d }`.e
+import fix.QuotedIdent._
+import fix.QuotedIdent.`a.b`.{c => _, _}
+
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.duration
 import scala.concurrent._
 import scala.concurrent.{Promise, Future}
-
-import fix.QuotedIdent.`a.b`.`{ d }`.e
-import fix.QuotedIdent._
-import fix.QuotedIdent.`a.b`.{c => _, _}
 
 object ImportsOrderKeep

--- a/output/src/main/scala/fix/ImportsOrderSymbolsFirst.scala
+++ b/output/src/main/scala/fix/ImportsOrderSymbolsFirst.scala
@@ -1,12 +1,12 @@
 package fix
 
+import fix.QuotedIdent._
+import fix.QuotedIdent.`a.b`.{c => _, _}
+import fix.QuotedIdent.`a.b`.`{ d }`.e
+
 import scala.concurrent._
 import scala.concurrent.{Promise, Future}
 import scala.concurrent.ExecutionContext.Implicits._
 import scala.concurrent.duration
-
-import fix.QuotedIdent._
-import fix.QuotedIdent.`a.b`.{c => _, _}
-import fix.QuotedIdent.`a.b`.`{ d }`.e
 
 object ImportsOrderSymbolsFirst

--- a/output/src/main/scala/fix/nested/NestedPackageWithBraces.scala
+++ b/output/src/main/scala/fix/nested/NestedPackageWithBraces.scala
@@ -1,12 +1,11 @@
 package fix {
   package nested {
+    import sun.misc.BASE64Encoder
+
     import java.time.Clock
     import javax.annotation.Generated
-
     import scala.collection.JavaConverters._
     import scala.concurrent.ExecutionContext
-
-    import sun.misc.BASE64Encoder
 
     object NestedPackageWithBraces
   }

--- a/rules/src/main/scala/fix/OrganizeImportsConfig.scala
+++ b/rules/src/main/scala/fix/OrganizeImportsConfig.scala
@@ -52,9 +52,8 @@ final case class OrganizeImportsConfig(
   groupExplicitlyImportedImplicitsSeparately: Boolean = false,
   groupedImports: GroupedImports = GroupedImports.Explode,
   groups: Seq[String] = Seq(
-    "re:javax?\\.",
-    "scala.",
-    "*"
+    "*",
+    "re:(javax?|scala)\\."
   ),
   importSelectorsOrder: ImportSelectorsOrder = ImportSelectorsOrder.Ascii,
   importsOrder: ImportsOrder = ImportsOrder.Ascii,


### PR DESCRIPTION
IntelliJ IDEA has recently changed the default order of import blocks. Would you @liancheng consider changing to the new scheme?

Since IDEA is the most used Scala IDE, it would make life much simpler for the majority of `scalafix-organize-imports` users.
