### PR TITLE
Align with IntelliJ

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -92,9 +92,9 @@ By default, `OrganizeImports` already removes unused imports for you (see the <<
 ----
 OrganizeImports {
   coalesceToWildcardImportThreshold = 2147483647 # Int.MaxValue
-  expandRelative = false
+  expandRelative = true
   groupExplicitlyImportedImplicitsSeparately = false
-  groupedImports = Explode
+  groupedImports = Merge
   groups = ["*", "re:(javax?|scala)\\."]
   importSelectorsOrder = Ascii
   importsOrder = Ascii
@@ -215,7 +215,7 @@ Boolean
 
 ==== Default value
 
-`false`
+`true`
 
 ==== Example
 
@@ -505,7 +505,7 @@ import scala.collection.mutable._
 
 ==== Default value
 
-`Explode`
+`Merge`
 
 Rationale:: Despite making the import section lengthier, exploding grouped imports into separate import statements is made the default behavior because it is more friendly to version control and less likely to create annoying merge conflicts caused by trivial import changes.
 

--- a/README.adoc
+++ b/README.adoc
@@ -92,7 +92,7 @@ By default, `OrganizeImports` already removes unused imports for you (see the <<
 ----
 OrganizeImports {
   coalesceToWildcardImportThreshold = 2147483647 # Int.MaxValue
-  expandRelative = true
+  expandRelative = false
   groupExplicitlyImportedImplicitsSeparately = false
   groupedImports = Merge
   groups = ["*", "re:(javax?|scala)\\."]
@@ -215,7 +215,7 @@ Boolean
 
 ==== Default value
 
-`true`
+`false`
 
 ==== Example
 

--- a/output/src/main/scala/ExpandRelativeRootPackage.scala
+++ b/output/src/main/scala/ExpandRelativeRootPackage.scala
@@ -1,6 +1,5 @@
 import P._
-import Q._
-import Q.x
+import Q.{x, _}
 
 object P {
   object x

--- a/output/src/main/scala/fix/CurlyBracedSingleImportee.scala
+++ b/output/src/main/scala/fix/CurlyBracedSingleImportee.scala
@@ -1,6 +1,5 @@
 package fix
 
-import scala.collection.Map
-import scala.collection.{Set => ImmutableSet}
+import scala.collection.{Map, Set => ImmutableSet}
 
 object CurlyBracedSingleImportee

--- a/output/src/main/scala/fix/DeduplicateImportees.scala
+++ b/output/src/main/scala/fix/DeduplicateImportees.scala
@@ -1,7 +1,5 @@
 package fix
 
-import scala.collection.immutable.Vector
-import scala.collection.immutable.{Set => _, _}
-import scala.collection.immutable.{Map => Dict}
+import scala.collection.immutable.{Map => Dict, Set => _, Vector, _}
 
 object DeduplicateImportees

--- a/output/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
+++ b/output/src/main/scala/fix/ExpandRelativeQuotedIdent.scala
@@ -1,8 +1,6 @@
 package fix
 
-import fix.QuotedIdent.`a.b`
-import fix.QuotedIdent.`a.b`.`{ d }`
-import fix.QuotedIdent.`a.b`.c
-import fix.QuotedIdent.`macro`
+import fix.QuotedIdent.`a.b`.{`{ d }`, c}
+import fix.QuotedIdent.{`a.b`, `macro`}
 
 object ExpandRelativeQuotedIdent

--- a/output/src/main/scala/fix/RelativeImports.scala
+++ b/output/src/main/scala/fix/RelativeImports.scala
@@ -1,10 +1,9 @@
 package fix
 
 import scala.util
+import scala.util.control
+import scala.util.control.NonFatal
 
 import sun.misc.BASE64Encoder
-
-import util.control
-import control.NonFatal
 
 object RelativeImports

--- a/output/src/main/scala/fix/RelativeImports.scala
+++ b/output/src/main/scala/fix/RelativeImports.scala
@@ -1,9 +1,10 @@
 package fix
 
 import scala.util
-import scala.util.control
-import scala.util.control.NonFatal
 
 import sun.misc.BASE64Encoder
+
+import util.control
+import control.NonFatal
 
 object RelativeImports

--- a/output/src/main/scala/fix/RemoveUnusedDisabled.scala
+++ b/output/src/main/scala/fix/RemoveUnusedDisabled.scala
@@ -1,12 +1,9 @@
 package fix
 
-import fix.UnusedImports.a.v1
-import fix.UnusedImports.a.v2
+import fix.UnusedImports.a.{v1, v2}
 import fix.UnusedImports.b.v3
-import fix.UnusedImports.c.{v5 => w1}
-import fix.UnusedImports.c.{v6 => w2}
-import fix.UnusedImports.d._
-import fix.UnusedImports.d.{v7 => unused}
+import fix.UnusedImports.c.{v5 => w1, v6 => w2}
+import fix.UnusedImports.d.{v7 => unused, _}
 
 object RemoveUnusedDisabled {
   import fix.UnusedImports.e.v9

--- a/output/src/main/scala/fix/RemoveUnusedRelative.scala
+++ b/output/src/main/scala/fix/RemoveUnusedRelative.scala
@@ -1,12 +1,9 @@
 package fix
 
-import fix.UnusedImports.a
 import fix.UnusedImports.a.v1
-import fix.UnusedImports.b
-import fix.UnusedImports.c
 import fix.UnusedImports.c.{v6 => w2}
-import fix.UnusedImports.d
 import fix.UnusedImports.d.{v7 => _, _}
+import fix.UnusedImports.{a, b, c, d}
 
 object RemoveUnusedRelative {
   val x1 = v1

--- a/rules/src/main/scala/fix/OrganizeImportsConfig.scala
+++ b/rules/src/main/scala/fix/OrganizeImportsConfig.scala
@@ -48,7 +48,7 @@ object GroupedImports {
 
 final case class OrganizeImportsConfig(
   coalesceToWildcardImportThreshold: Int = Int.MaxValue,
-  expandRelative: Boolean = true,
+  expandRelative: Boolean = false,
   groupExplicitlyImportedImplicitsSeparately: Boolean = false,
   groupedImports: GroupedImports = GroupedImports.Merge,
   groups: Seq[String] = Seq(

--- a/rules/src/main/scala/fix/OrganizeImportsConfig.scala
+++ b/rules/src/main/scala/fix/OrganizeImportsConfig.scala
@@ -48,9 +48,9 @@ object GroupedImports {
 
 final case class OrganizeImportsConfig(
   coalesceToWildcardImportThreshold: Int = Int.MaxValue,
-  expandRelative: Boolean = false,
+  expandRelative: Boolean = true,
   groupExplicitlyImportedImplicitsSeparately: Boolean = false,
-  groupedImports: GroupedImports = GroupedImports.Explode,
+  groupedImports: GroupedImports = GroupedImports.Merge,
   groups: Seq[String] = Seq(
     "*",
     "re:(javax?|scala)\\."


### PR DESCRIPTION
 * `groupedImports = Merge` to prevent conflict with IntelliJ
 * `expandRelative = true` to make converging with IntelliJ's _Optimize imports_ faster

Maybe there are other changes necessary to match IntelliJ 100%, but from my experience over many months, using
```hocon
OrganizeImports {
  expandRelative = true
  groupedImports = Merge
  groups = [
    "*"
    "re:(javax?|scala)\\."
  ]
}
```
doesn't cause any conflicts between IntelliJ and `scalafix-organize-imports`.