### PR TITLE
[Scala 3] Add support for given imports

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -88,8 +88,7 @@ Running the rule on source files compiled with Scala 3 is still experimental.
 Known limitations:
 
 . You must use Scalafix 0.9.28 or later
-. The <<removeUnused, `removeUnused`>> option must be explicitly set to `false`
-. Source files using new syntax introduced in Scala 3 such as https://docs.scala-lang.org/scala3/book/ca-given-imports.html[`given` imports] may not work properly 
+. The <<removeUnused, `removeUnused`>> option must be explicitly set to `false` - the rule currently doesn't remove unused imports as it's currently not supported by the compiler.
 . Usage of http://dotty.epfl.ch/docs/reference/dropped-features/package-objects.html[deprecated package objects] may result in incorrect imports
 . The <<groupExplicitlyImportedImplicitsSeparately, groupExplicitlyImportedImplicitsSeparately>> option has no effect
 

--- a/input/src/main/scala-3/fix/CoalesceGivenImportees.scala
+++ b/input/src/main/scala-3/fix/CoalesceGivenImportees.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  coalesceToWildcardImportThreshold = 2
+  removeUnused = false
+}
+ */
+package fix
+
+import fix.GivenImports.{Alpha, Beta, Zeta}
+import fix.GivenImports.{given Alpha, given Beta, given Zeta}
+
+object CoalesceGivenImportees

--- a/input/src/main/scala-3/fix/DeduplicateGivenImportees.scala
+++ b/input/src/main/scala-3/fix/DeduplicateGivenImportees.scala
@@ -1,0 +1,13 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+package fix
+
+import fix.GivenImports._
+import fix.GivenImports.{given Beta, given Alpha}
+import fix.GivenImports.given Beta
+import fix.GivenImports.given Alpha
+import fix.GivenImports.given Alpha
+
+object DeduplicateGivenImportees

--- a/input/src/main/scala-3/fix/ExpandGiven.scala
+++ b/input/src/main/scala-3/fix/ExpandGiven.scala
@@ -1,0 +1,12 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+package fix
+
+import fix.GivenImports.Beta
+import fix.GivenImports.Alpha
+import fix.GivenImports.{given Beta, given Alpha}
+import scala.util.Either
+
+object ExpandGiven

--- a/input/src/main/scala-3/fix/ExpandUnimportGiven.scala
+++ b/input/src/main/scala-3/fix/ExpandUnimportGiven.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+ */
+package fix
+
+import fix.GivenImports.Beta
+import fix.GivenImports.Alpha
+import fix.GivenImports.{given Alpha}
+import fix.GivenImports.{alpha => _}
+import fix.GivenImports.{beta => _, given}
+import scala.util.Either
+
+object ExpandUnimportGiven

--- a/input/src/main/scala-3/fix/GroupedGivenImportsMergeUnimports.scala
+++ b/input/src/main/scala-3/fix/GroupedGivenImportsMergeUnimports.scala
@@ -1,0 +1,19 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+OrganizeImports.groupedImports = Merge
+ */
+package fix
+
+import fix.GivenImports._
+import fix.GivenImports.{alpha => _, given}
+import fix.GivenImports.{ given Beta }
+import fix.GivenImports.{gamma => _, given}
+import fix.GivenImports.{ given Zeta }
+
+import fix.GivenImports2.{alpha => _}
+import fix.GivenImports2.{beta => _}
+import fix.GivenImports2.{ given Gamma }
+import fix.GivenImports2.{ given Zeta }
+
+object GroupedGivenImportsMergeUnimports

--- a/input/src/main/scala-3/fix/GroupedImportsAggressiveMergeGivenAll.scala
+++ b/input/src/main/scala-3/fix/GroupedImportsAggressiveMergeGivenAll.scala
@@ -1,0 +1,23 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+OrganizeImports.groupedImports = AggressiveMerge
+ */
+package fix
+
+import fix.MergeImports.Wildcard1._
+import fix.MergeImports.Wildcard1.{a => _, _}
+import fix.MergeImports.Wildcard1.{b => B}
+import fix.MergeImports.Wildcard1.{c => _, _}
+import fix.MergeImports.Wildcard1.d
+
+import fix.GivenImports._
+import fix.GivenImports.{Alpha, Beta, Zeta}
+import fix.GivenImports.{given Alpha, given Beta, given Zeta}
+import fix.GivenImports.given
+
+import fix.MergeImports.Wildcard2._
+import fix.MergeImports.Wildcard2.{a, b}
+
+
+object GroupedImportsAggressiveMergeGivenAll

--- a/input/src/main/scala-3/fix/MergeGiven.scala
+++ b/input/src/main/scala-3/fix/MergeGiven.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+OrganizeImports.groupedImports = Merge
+ */
+package fix
+
+import fix.GivenImports.Beta
+import fix.GivenImports.Alpha
+import fix.GivenImports.{given Beta}
+import fix.GivenImports.{given Alpha}
+import scala.util.Either
+
+object MergeGiven

--- a/output/src/main/scala-3/fix/CoalesceGivenImportees.scala
+++ b/output/src/main/scala-3/fix/CoalesceGivenImportees.scala
@@ -1,0 +1,6 @@
+package fix
+
+import fix.GivenImports._
+import fix.GivenImports.given
+
+object CoalesceGivenImportees

--- a/output/src/main/scala-3/fix/DeduplicateGivenImportees.scala
+++ b/output/src/main/scala-3/fix/DeduplicateGivenImportees.scala
@@ -1,0 +1,7 @@
+package fix
+
+import fix.GivenImports._
+import fix.GivenImports.{ given Alpha }
+import fix.GivenImports.{ given Beta }
+
+object DeduplicateGivenImportees

--- a/output/src/main/scala-3/fix/ExpandGiven.scala
+++ b/output/src/main/scala-3/fix/ExpandGiven.scala
@@ -1,0 +1,10 @@
+package fix
+
+import fix.GivenImports.Alpha
+import fix.GivenImports.Beta
+import fix.GivenImports.{ given Alpha }
+import fix.GivenImports.{ given Beta }
+
+import scala.util.Either
+
+object ExpandGiven

--- a/output/src/main/scala-3/fix/ExpandUnimportGiven.scala
+++ b/output/src/main/scala-3/fix/ExpandUnimportGiven.scala
@@ -1,0 +1,11 @@
+package fix
+
+import fix.GivenImports.Alpha
+import fix.GivenImports.Beta
+import fix.GivenImports.{given Alpha}
+import fix.GivenImports.{alpha => _}
+import fix.GivenImports.{beta => _, given}
+
+import scala.util.Either
+
+object ExpandUnimportGiven

--- a/output/src/main/scala-3/fix/GroupedGivenImportsMergeUnimports.scala
+++ b/output/src/main/scala-3/fix/GroupedGivenImportsMergeUnimports.scala
@@ -1,0 +1,8 @@
+package fix
+
+import fix.GivenImports._
+import fix.GivenImports.{gamma => _, given Beta, given Zeta, given}
+import fix.GivenImports2.{alpha => _, beta => _}
+import fix.GivenImports2.{given Gamma, given Zeta}
+
+object GroupedGivenImportsMergeUnimports

--- a/output/src/main/scala-3/fix/GroupedImportsAggressiveMergeGivenAll.scala
+++ b/output/src/main/scala-3/fix/GroupedImportsAggressiveMergeGivenAll.scala
@@ -1,0 +1,10 @@
+package fix
+
+import fix.GivenImports._
+import fix.GivenImports.given
+import fix.MergeImports.Wildcard1._
+import fix.MergeImports.Wildcard1.{b => B}
+import fix.MergeImports.Wildcard2._
+
+
+object GroupedImportsAggressiveMergeGivenAll

--- a/output/src/main/scala-3/fix/MergeGiven.scala
+++ b/output/src/main/scala-3/fix/MergeGiven.scala
@@ -1,0 +1,8 @@
+package fix
+
+import fix.GivenImports.{Alpha, Beta}
+import fix.GivenImports.{given Alpha, given Beta}
+
+import scala.util.Either
+
+object MergeGiven

--- a/shared/src/main/scala-3/fix/GivenImports.scala
+++ b/shared/src/main/scala-3/fix/GivenImports.scala
@@ -1,0 +1,22 @@
+package fix
+
+object GivenImports {
+  trait Alpha
+  trait Beta
+  trait Gamma
+  trait Zeta
+  
+  given alpha: Alpha with {}
+  given beta: Beta with {}
+  given gamma: Gamma with {}
+  given zeta: Zeta with {}
+}
+
+object GivenImports2 {
+  import GivenImports.*
+  
+  given alpha: Alpha with {}
+  given beta: Beta with {}
+  given gamma: Gamma with {}
+  given zeta: Zeta with {}
+}


### PR DESCRIPTION
Previously, organize-imports-rule would throw an exception in case of given imports, now it should sort them correctly. Currently they will be sorted separately at the end, but we can add some more options. However I am not sure what will be the best practises here. We could possibly have an option to put them at the end, but I think the current situation is fine for now.

~~You cannot unimport given imports, so we don't have do do anything similar to wildcard improts when it comes to given wildcard imports.~~ You can actually

~~Tests are currently blocked on https://github.com/liancheng/scalafix-organize-imports/pull/179 , I only checked it manually.~~ We have tests now! :tada: 

@bjaglin should we wait for that?

I thought of raising an issue, but turned out faster to fix it :sweat_smile: If there are some other plans here, feel free to close the PR

![dotty-example-project-1623409805016](https://user-images.githubusercontent.com/3807253/121677603-63134d00-cab6-11eb-83b1-898a948e11ef.gif)
