### PR TITLE
Run the CI jobs using JDK 11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.4
       - uses: olafurpg/setup-scala@v12
+        with:
+          java-version: adopt@1.11
       - uses: coursier/cache-action@v6
       - name: Lint
         run: sbt scalafmtCheckAll "rules2_12/scalafix --check"

--- a/input/src/main/scala/OrganizeImportsRootPackage.scala
+++ b/input/src/main/scala/OrganizeImportsRootPackage.scala
@@ -5,8 +5,8 @@ OrganizeImports.groups = ["re:javax?\\.", "*", "scala."]
  */
 import java.time.Clock
 import scala.collection.JavaConverters._
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 import scala.concurrent.ExecutionContext
-import javax.annotation.Generated
+import javax.net.ssl
 
 object OrganizeImportsRootPackage

--- a/input/src/main/scala/fix/Groups.scala
+++ b/input/src/main/scala/fix/Groups.scala
@@ -7,8 +7,8 @@ package fix
 
 import java.time.Clock
 import scala.collection.JavaConverters._
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 import scala.concurrent.ExecutionContext
-import javax.annotation.Generated
+import javax.net.ssl
 
 object Groups

--- a/input/src/main/scala/fix/GroupsLongestMatch.scala
+++ b/input/src/main/scala/fix/GroupsLongestMatch.scala
@@ -7,9 +7,9 @@ package fix
 
 import java.time.Clock
 import scala.collection.JavaConverters._
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 import scala.concurrent.ExecutionContext
-import javax.annotation.Generated
+import javax.net.ssl
 import scala.util.control.NonFatal
 import scala.util.Random
 

--- a/input/src/main/scala/fix/RelativeImports.scala
+++ b/input/src/main/scala/fix/RelativeImports.scala
@@ -6,7 +6,7 @@ OrganizeImports.groups = ["scala.", "*"]
 package fix
 
 import scala.util
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 import util.control
 import control.NonFatal
 

--- a/input/src/main/scala/fix/Suppression.scala
+++ b/input/src/main/scala/fix/Suppression.scala
@@ -8,9 +8,9 @@ package fix
 // scalafix:off
 import java.time.Clock
 import scala.collection.JavaConverters._
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 import scala.concurrent.ExecutionContext
-import javax.annotation.Generated
+import javax.net.ssl
 // scalafix:on
 
 object Suppression

--- a/input/src/main/scala/fix/nested/NestedPackage.scala
+++ b/input/src/main/scala/fix/nested/NestedPackage.scala
@@ -8,8 +8,8 @@ package nested
 
 import java.time.Clock
 import scala.collection.JavaConverters._
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 import scala.concurrent.ExecutionContext
-import javax.annotation.Generated
+import javax.net.ssl
 
 object OrganizeImportsNestedPackage

--- a/input/src/main/scala/fix/nested/NestedPackageWithBraces.scala
+++ b/input/src/main/scala/fix/nested/NestedPackageWithBraces.scala
@@ -6,9 +6,9 @@ package fix {
   package nested {
     import java.time.Clock
     import scala.collection.JavaConverters._
-    import sun.misc.BASE64Encoder
+    import sun.misc.Unsafe
     import scala.concurrent.ExecutionContext
-    import javax.annotation.Generated
+    import javax.net.ssl
 
     object NestedPackageWithBraces
   }

--- a/output/src/main/scala/OrganizeImportsRootPackage.scala
+++ b/output/src/main/scala/OrganizeImportsRootPackage.scala
@@ -1,7 +1,7 @@
 import java.time.Clock
-import javax.annotation.Generated
+import javax.net.ssl
 
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext

--- a/output/src/main/scala/fix/Groups.scala
+++ b/output/src/main/scala/fix/Groups.scala
@@ -1,9 +1,9 @@
 package fix
 
 import java.time.Clock
-import javax.annotation.Generated
+import javax.net.ssl
 
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext

--- a/output/src/main/scala/fix/GroupsLongestMatch.scala
+++ b/output/src/main/scala/fix/GroupsLongestMatch.scala
@@ -1,7 +1,7 @@
 package fix
 
 import java.time.Clock
-import javax.annotation.Generated
+import javax.net.ssl
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
@@ -9,6 +9,6 @@ import scala.concurrent.ExecutionContext
 import scala.util.Random
 import scala.util.control.NonFatal
 
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 
 object GroupsLongestMatch

--- a/output/src/main/scala/fix/RelativeImports.scala
+++ b/output/src/main/scala/fix/RelativeImports.scala
@@ -2,7 +2,7 @@ package fix
 
 import scala.util
 
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 
 import util.control
 import control.NonFatal

--- a/output/src/main/scala/fix/Suppression.scala
+++ b/output/src/main/scala/fix/Suppression.scala
@@ -3,9 +3,9 @@ package fix
 // scalafix:off
 import java.time.Clock
 import scala.collection.JavaConverters._
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 import scala.concurrent.ExecutionContext
-import javax.annotation.Generated
+import javax.net.ssl
 // scalafix:on
 
 object Suppression

--- a/output/src/main/scala/fix/nested/NestedPackage.scala
+++ b/output/src/main/scala/fix/nested/NestedPackage.scala
@@ -2,9 +2,9 @@ package fix
 package nested
 
 import java.time.Clock
-import javax.annotation.Generated
+import javax.net.ssl
 
-import sun.misc.BASE64Encoder
+import sun.misc.Unsafe
 
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext

--- a/output/src/main/scala/fix/nested/NestedPackageWithBraces.scala
+++ b/output/src/main/scala/fix/nested/NestedPackageWithBraces.scala
@@ -1,9 +1,9 @@
 package fix {
   package nested {
-    import sun.misc.BASE64Encoder
+    import sun.misc.Unsafe
 
     import java.time.Clock
-    import javax.annotation.Generated
+    import javax.net.ssl
     import scala.collection.JavaConverters._
     import scala.concurrent.ExecutionContext
 

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -181,9 +181,6 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
   )(implicit doc: SemanticDocument): (Seq[Importer], Seq[Importer]) = {
     val (implicits, implicitPositions) = importers.flatMap {
       case importer @ Importer(_, importees) =>
-        importees.foreach { i =>
-          println(i.symbol.info)
-        }
         importees collect {
           case i: Importee.Name if i.symbol.infoNoThrow exists (_.isImplicit) =>
             importer.copy(importees = i :: Nil) -> i.pos


### PR DESCRIPTION
- Remove classes removed in JDK 11 from test cases
- Use JDK 11 in the CI job
