### PR TITLE
Fix given imports ordering

### DIFF
--- a/output/src/main/scala-3/fix/DeduplicateGivenImportees.scala
+++ b/output/src/main/scala-3/fix/DeduplicateGivenImportees.scala
@@ -1,7 +1,7 @@
 package fix
 
 import fix.GivenImports._
-import fix.GivenImports.{ given Alpha }
-import fix.GivenImports.{ given Beta }
+import fix.GivenImports.{given Alpha}
+import fix.GivenImports.{given Beta}
 
 object DeduplicateGivenImportees

--- a/output/src/main/scala-3/fix/ExpandGiven.scala
+++ b/output/src/main/scala-3/fix/ExpandGiven.scala
@@ -2,8 +2,8 @@ package fix
 
 import fix.GivenImports.Alpha
 import fix.GivenImports.Beta
-import fix.GivenImports.{ given Alpha }
-import fix.GivenImports.{ given Beta }
+import fix.GivenImports.{given Alpha}
+import fix.GivenImports.{given Beta}
 
 import scala.util.Either
 

--- a/output/src/main/scala-3/fix/ExpandUnimportGiven.scala
+++ b/output/src/main/scala-3/fix/ExpandUnimportGiven.scala
@@ -2,9 +2,9 @@ package fix
 
 import fix.GivenImports.Alpha
 import fix.GivenImports.Beta
-import fix.GivenImports.{given Alpha}
 import fix.GivenImports.{alpha => _}
 import fix.GivenImports.{beta => _, given}
+import fix.GivenImports.{given Alpha}
 
 import scala.util.Either
 

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -864,18 +864,6 @@ object OrganizeImports {
     }
   }
 
-  object Renames {
-    def unapply(importees: Seq[Importee]): Option[Seq[Importee.Rename]] = importees match {
-      case Importees(_, renames, _, _, _, _) => Option(renames)
-    }
-  }
-
-  object Unimports {
-    def unapply(importees: Seq[Importee]): Option[Seq[Importee.Unimport]] = importees match {
-      case Importees(_, _, unimports, _, _, _) => Option(unimports)
-    }
-  }
-
   implicit private class SymbolExtension(symbol: Symbol) {
 
     /**
@@ -892,12 +880,10 @@ object OrganizeImports {
   implicit private class ImporterExtension(importer: Importer) {
 
     /** Checks whether the `Importer` is curly-braced when pretty-printed. */
-    def isCurlyBraced: Boolean =
-      importer.importees match {
-        case Renames(_ :: _) | Unimports(_ :: _) => true // At least one rename or unimport
-        case importees if importees.length > 1   => true // More than one importees
-        case _                                   => false
-      }
+    def isCurlyBraced: Boolean = {
+      val importees @ Importees(_, renames, unimports, givens, _, _) = importer.importees
+      renames.nonEmpty || unimports.nonEmpty || givens.nonEmpty || importees.length > 1
+    }
 
     /**
      * Returns an `Importer` with all the `Importee`s that are selected from the input `Importer`


### PR DESCRIPTION
Scalameta adds extra spaces inside the braces when pretty-printing `given` imports, e.g.:

```
imports foo.{ give Bar }
```

instead of

```
imports foo.{give Bar}
```

This affects import ordering since we sort imports by comparing the pretty-print result.

This PR fixes this issue by adjusting the `isCurlyBraced` function, which is a narrow waist for fixing similar pretty-printing issues, to include `given` imports.

Note that, Scala 3 actually does not require a single `given` importee to be curly braced, i.e., `import foo.given Bar` is valid. However, Scalameta right now always braces them. This issue is fixed in scalameta/scalameta#2425, but we need to wait for a new Scalameta release containing this fix. For now, we still consider `given` imports to be curly braced.
