### PR TITLE
Coalesce given imports

### DIFF
--- a/input/src/main/scala-3/fix/CoalesceImporteesGivensAndNames.scala
+++ b/input/src/main/scala-3/fix/CoalesceImporteesGivensAndNames.scala
@@ -1,0 +1,14 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  coalesceToWildcardImportThreshold = 2
+  removeUnused = false
+}
+ */
+package fix
+
+import fix.Givens._
+import fix.Givens.{A, B => B1, C => _, given D, _}
+
+object CoalesceImporteesGivensAndNames

--- a/input/src/main/scala-3/fix/CoalesceImporteesNoGivens.scala
+++ b/input/src/main/scala-3/fix/CoalesceImporteesNoGivens.scala
@@ -1,0 +1,13 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  coalesceToWildcardImportThreshold = 2
+  removeUnused = false
+}
+ */
+package fix
+
+import fix.Givens.{A, B, C => C1}
+
+object CoalesceImporteesNoGivens

--- a/input/src/main/scala-3/fix/CoalesceImporteesNoGivensNoNames.scala
+++ b/input/src/main/scala-3/fix/CoalesceImporteesNoGivensNoNames.scala
@@ -1,0 +1,13 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports {
+  groupedImports = Keep
+  coalesceToWildcardImportThreshold = 2
+  removeUnused = false
+}
+ */
+package fix
+
+import fix.Givens.{A => A1, B => _, _}
+
+object CoalesceImporteesNoGivensNoNames

--- a/input/src/main/scala-3/fix/CoalesceImporteesNoNames.scala
+++ b/input/src/main/scala-3/fix/CoalesceImporteesNoNames.scala
@@ -8,7 +8,7 @@ OrganizeImports {
  */
 package fix
 
-import fix.GivenImports.{Alpha, Beta, Zeta}
-import fix.GivenImports.{given Alpha, given Beta, given Zeta}
+import fix.Givens._
+import fix.Givens.{A => A1, given B, given C}
 
-object CoalesceGivenImportees
+object CoalesceImporteesNoNames

--- a/input/src/main/scala-3/fix/GroupedGivenImportsMergeUnimports.scala
+++ b/input/src/main/scala-3/fix/GroupedGivenImportsMergeUnimports.scala
@@ -7,13 +7,13 @@ package fix
 
 import fix.GivenImports._
 import fix.GivenImports.{alpha => _, given}
-import fix.GivenImports.{ given Beta }
+import fix.GivenImports.{given Beta}
 import fix.GivenImports.{gamma => _, given}
-import fix.GivenImports.{ given Zeta }
+import fix.GivenImports.{given Zeta}
 
 import fix.GivenImports2.{alpha => _}
 import fix.GivenImports2.{beta => _}
-import fix.GivenImports2.{ given Gamma }
-import fix.GivenImports2.{ given Zeta }
+import fix.GivenImports2.{given Gamma}
+import fix.GivenImports2.{given Zeta}
 
 object GroupedGivenImportsMergeUnimports

--- a/output/src/main/scala-3/fix/CoalesceGivenImportees.scala
+++ b/output/src/main/scala-3/fix/CoalesceGivenImportees.scala
@@ -1,6 +1,0 @@
-package fix
-
-import fix.GivenImports._
-import fix.GivenImports.given
-
-object CoalesceGivenImportees

--- a/output/src/main/scala-3/fix/CoalesceImporteesGivensAndNames.scala
+++ b/output/src/main/scala-3/fix/CoalesceImporteesGivensAndNames.scala
@@ -1,0 +1,6 @@
+package fix
+
+import fix.Givens._
+import fix.Givens.{B => B1, C => _, given, _}
+
+object CoalesceImporteesGivensAndNames

--- a/output/src/main/scala-3/fix/CoalesceImporteesNoGivens.scala
+++ b/output/src/main/scala-3/fix/CoalesceImporteesNoGivens.scala
@@ -1,0 +1,5 @@
+package fix
+
+import fix.Givens.{C => C1, _}
+
+object CoalesceImporteesNoGivens

--- a/output/src/main/scala-3/fix/CoalesceImporteesNoGivensNoNames.scala
+++ b/output/src/main/scala-3/fix/CoalesceImporteesNoGivensNoNames.scala
@@ -1,0 +1,5 @@
+package fix
+
+import fix.Givens.{A => A1, B => _, _}
+
+object CoalesceImporteesNoGivensNoNames

--- a/output/src/main/scala-3/fix/CoalesceImporteesNoNames.scala
+++ b/output/src/main/scala-3/fix/CoalesceImporteesNoNames.scala
@@ -1,0 +1,6 @@
+package fix
+
+import fix.Givens._
+import fix.Givens.{A => A1, given}
+
+object CoalesceImporteesNoNames

--- a/shared/src/main/scala-3/fix/GivenImports.scala
+++ b/shared/src/main/scala-3/fix/GivenImports.scala
@@ -4,19 +4,22 @@ object GivenImports {
   trait Alpha
   trait Beta
   trait Gamma
+  trait Delta
   trait Zeta
-  
-  given alpha: Alpha with {}
-  given beta: Beta with {}
-  given gamma: Gamma with {}
-  given zeta: Zeta with {}
+
+  given alpha: Alpha = ???
+  given beta: Beta = ???
+  given gamma: Gamma = ???
+  given delta: Delta = ???
+  given zeta: Zeta = ???
 }
 
 object GivenImports2 {
   import GivenImports.*
-  
-  given alpha: Alpha with {}
-  given beta: Beta with {}
-  given gamma: Gamma with {}
-  given zeta: Zeta with {}
+
+  given alpha: Alpha = ???
+  given beta: Beta = ???
+  given gamma: Gamma = ???
+  given delta: Delta = ???
+  given zeta: Zeta = ???
 }

--- a/shared/src/main/scala-3/fix/Givens.scala
+++ b/shared/src/main/scala-3/fix/Givens.scala
@@ -1,0 +1,15 @@
+package fix
+
+object Givens {
+  trait A
+  trait B
+  trait C
+  trait D
+  trait E
+
+  given a: A = ???
+  given b: B = ???
+  given c: C = ???
+  given d: D = ???
+  given e: E = ???
+}


### PR DESCRIPTION
Importee coalescing is not working properly after #187. When the total number of `given` and named importees exceed the threshold, we should also trigger coalescing.

Applying the following diff to commit 0122d0c159936ab839f0297a6f089618aeb12d1f results a test failure:

```diff
diff --git a/input/src/main/scala-3/fix/CoalesceGivenImportees.scala b/input/src/main/scala-3/fix/CoalesceGivenImportees.scala
index fec33b9..5b349d6 100644
--- a/input/src/main/scala-3/fix/CoalesceGivenImportees.scala
+++ b/input/src/main/scala-3/fix/CoalesceGivenImportees.scala
@@ -9,6 +9,6 @@ OrganizeImports {
 package fix
 
 import fix.GivenImports.{Alpha, Beta, Zeta}
-import fix.GivenImports.{given Alpha, given Beta, given Zeta}
+import fix.GivenImports.{Alpha, given Beta, given Zeta}
 
 object CoalesceGivenImportees
diff --git a/output/src/main/scala-3/fix/CoalesceGivenImportees.scala b/output/src/main/scala-3/fix/CoalesceGivenImportees.scala
index 0c304af..d3ab201 100644
--- a/output/src/main/scala-3/fix/CoalesceGivenImportees.scala
+++ b/output/src/main/scala-3/fix/CoalesceGivenImportees.scala
@@ -1,6 +1,5 @@
 package fix
 
-import fix.GivenImports._
-import fix.GivenImports.given
+import fix.GivenImports.{given, _}
 
 object CoalesceGivenImportees
```

```
===========
=> Obtained
===========

package fix

import fix.GivenImports._
import fix.GivenImports.{given Beta, given Zeta}

object CoalesceGivenImportees


=======
=> Diff
=======
--- obtained
+++ expected
@@ -2,4 +2,3 @@
∙
-import fix.GivenImports._
-import fix.GivenImports.{given Beta, given Zeta}
+import fix.GivenImports.{given, _}
```