### PR TITLE
Update sbt-scalafix to 0.9.30

### DIFF
--- a/input/src/main/scala-3/fix/ExpandUnimportGiven.scala
+++ b/input/src/main/scala-3/fix/ExpandUnimportGiven.scala
@@ -6,7 +6,7 @@ package fix
 
 import fix.GivenImports.Beta
 import fix.GivenImports.Alpha
-import fix.GivenImports.{given Alpha}
+import fix.GivenImports.given Alpha
 import fix.GivenImports.{alpha => _}
 import fix.GivenImports.{beta => _, given}
 import scala.util.Either

--- a/output/src/main/scala-3/fix/DeduplicateGivenImportees.scala
+++ b/output/src/main/scala-3/fix/DeduplicateGivenImportees.scala
@@ -1,7 +1,7 @@
 package fix
 
 import fix.GivenImports._
-import fix.GivenImports.{given Alpha}
-import fix.GivenImports.{given Beta}
+import fix.GivenImports.given Alpha
+import fix.GivenImports.given Beta
 
 object DeduplicateGivenImportees

--- a/output/src/main/scala-3/fix/ExpandGiven.scala
+++ b/output/src/main/scala-3/fix/ExpandGiven.scala
@@ -2,8 +2,8 @@ package fix
 
 import fix.GivenImports.Alpha
 import fix.GivenImports.Beta
-import fix.GivenImports.{given Alpha}
-import fix.GivenImports.{given Beta}
+import fix.GivenImports.given Alpha
+import fix.GivenImports.given Beta
 
 import scala.util.Either
 

--- a/output/src/main/scala-3/fix/ExpandUnimportGiven.scala
+++ b/output/src/main/scala-3/fix/ExpandUnimportGiven.scala
@@ -2,9 +2,9 @@ package fix
 
 import fix.GivenImports.Alpha
 import fix.GivenImports.Beta
+import fix.GivenImports.given Alpha
 import fix.GivenImports.{alpha => _}
 import fix.GivenImports.{beta => _, given}
-import fix.GivenImports.{given Alpha}
 
 import scala.util.Either
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += Resolver.sonatypeRepo("releases")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.29")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.30")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.3")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -880,8 +880,8 @@ object OrganizeImports {
 
     /** Checks whether the `Importer` is curly-braced when pretty-printed. */
     def isCurlyBraced: Boolean = {
-      val importees @ Importees(_, renames, unimports, givens, _, _) = importer.importees
-      renames.nonEmpty || unimports.nonEmpty || givens.nonEmpty || importees.length > 1
+      val importees @ Importees(_, renames, unimports, _, _, _) = importer.importees
+      renames.nonEmpty || unimports.nonEmpty || importees.length > 1
     }
 
     /**


### PR DESCRIPTION
This PR supercedes PR #200.

The test failure occurred in PR #200 is due to an issue fixed in scalameta/scalameta#2425. Due to that issue, we previously also wrap imports with only a single `Given` import with curly braces. This is no longer needed in Scalafix and sbt-scalafix 0.9.30.
