### PR TITLE
Refactoring support for `given` imports

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 lazy val v = _root_.scalafix.sbt.BuildInfo
-
 lazy val rulesCrossVersions = Seq(v.scala213, v.scala212, v.scala211)
 lazy val scala3Version = "3.0.1"
 
@@ -40,6 +39,7 @@ lazy val `scalafix-organize-imports` = project
   .settings(
     publish / skip := true
   )
+
 lazy val rules = projectMatrix
   .settings(
     moduleName := "organize-imports",
@@ -110,25 +110,17 @@ lazy val tests = projectMatrix
     scalafixTestkitOutputSourceDirectories :=
       TargetAxis.resolve(output, Compile / unmanagedSourceDirectories).value,
     scalafixTestkitInputSourceDirectories := {
-      val inputSrc = TargetAxis.resolve(
-        input,
-        Compile / unmanagedSourceDirectories
-      ).value
-      val inputUnusedImportsSrc = TargetAxis.resolve(
-        inputUnusedImports,
-        Compile / unmanagedSourceDirectories
-      ).value
+      val inputSrc =
+        TargetAxis.resolve(input, Compile / unmanagedSourceDirectories).value
+      val inputUnusedImportsSrc =
+        TargetAxis.resolve(inputUnusedImports, Compile / unmanagedSourceDirectories).value
       inputSrc ++ inputUnusedImportsSrc
     },
     scalafixTestkitInputClasspath := {
-      val inputClasspath = TargetAxis.resolve(
-        input,
-        Compile / fullClasspath
-      ).value
-      val inputUnusedImportsClasspath = TargetAxis.resolve(
-        inputUnusedImports,
-        Compile / fullClasspath
-      ).value
+      val inputClasspath =
+        TargetAxis.resolve(input, Compile / fullClasspath).value
+      val inputUnusedImportsClasspath =
+        TargetAxis.resolve(inputUnusedImports, Compile / fullClasspath).value
       inputClasspath ++ inputUnusedImportsClasspath
     },
     scalafixTestkitInputScalacOptions :=

--- a/input/src/main/scala-3/fix/DeduplicateGivenImportees.scala
+++ b/input/src/main/scala-3/fix/DeduplicateGivenImportees.scala
@@ -6,8 +6,8 @@ package fix
 
 import fix.Givens._
 import fix.Givens.{given A, given B}
-import fix.Givens.{given A}
-import fix.Givens.{given C}
-import fix.Givens.{given C}
+import fix.Givens.given A
+import fix.Givens.given C
+import fix.Givens.given C
 
 object DeduplicateGivenImportees

--- a/input/src/main/scala-3/fix/DeduplicateGivenImportees.scala
+++ b/input/src/main/scala-3/fix/DeduplicateGivenImportees.scala
@@ -4,10 +4,10 @@ OrganizeImports.removeUnused = false
  */
 package fix
 
-import fix.GivenImports._
-import fix.GivenImports.{given Beta, given Alpha}
-import fix.GivenImports.given Beta
-import fix.GivenImports.given Alpha
-import fix.GivenImports.given Alpha
+import fix.Givens._
+import fix.Givens.{given A, given B}
+import fix.Givens.{given A}
+import fix.Givens.{given C}
+import fix.Givens.{given C}
 
 object DeduplicateGivenImportees

--- a/output/src/main/scala-3/fix/CoalesceImporteesGivensAndNames.scala
+++ b/output/src/main/scala-3/fix/CoalesceImporteesGivensAndNames.scala
@@ -1,6 +1,6 @@
 package fix
 
 import fix.Givens._
-import fix.Givens.{B => B1, C => _, given, _}
+import fix.Givens.{B => B1, C => _, _, given}
 
 object CoalesceImporteesGivensAndNames

--- a/output/src/main/scala-3/fix/DeduplicateGivenImportees.scala
+++ b/output/src/main/scala-3/fix/DeduplicateGivenImportees.scala
@@ -1,7 +1,8 @@
 package fix
 
-import fix.GivenImports._
-import fix.GivenImports.given Alpha
-import fix.GivenImports.given Beta
+import fix.Givens._
+import fix.Givens.given A
+import fix.Givens.given B
+import fix.Givens.given C
 
 object DeduplicateGivenImportees

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -561,12 +561,12 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
 
     // The Scala language spec allows an import expression to have at most one final wildcard, which
     // can only appears in the last position.
-    val (wildcard, noWildcard) =
+    val (wildcards, noWildcard) =
       importer.importees partition (i => i.is[Importee.Wildcard] || i.is[Importee.GivenAll])
 
     val orderedImportees = config.importSelectorsOrder match {
-      case Ascii        => noWildcard.sortBy(_.syntax) ++ wildcard
-      case SymbolsFirst => sortImporteesSymbolsFirst(noWildcard) ++ wildcard
+      case Ascii        => Seq(noWildcard, wildcards) map (_.sortBy(_.syntax)) reduce (_ ++ _)
+      case SymbolsFirst => Seq(noWildcard, wildcards) map sortImporteesSymbolsFirst reduce (_ ++ _)
       case Keep         => importer.importees
     }
 

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -16,6 +16,8 @@ import metaconfig.Configured
 import metaconfig.internal.ConfGet
 import scala.meta.Import
 import scala.meta.Importee
+import scala.meta.Importee.GivenAll
+import scala.meta.Importee.Wildcard
 import scala.meta.Importer
 import scala.meta.Name
 import scala.meta.Pkg
@@ -201,19 +203,19 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
 
     (
       // The owner of the top qualifier is `_root_`, e.g.: `import scala.util`
-      owner.isRootPackage
+      owner.isRootPackage ||
 
       // The top qualifier is a top-level class/trait/object defined under no packages. In this
       // case, Scalameta defines the owner to be the empty package.
-      || owner.isEmptyPackage
+      owner.isEmptyPackage ||
 
       // The top qualifier itself is `_root_`, e.g.: `import _root_.scala.util`
-      || topQualifier.value == "_root_"
+      topQualifier.value == "_root_" ||
 
       // Issue #64: Sometimes, the symbol of the top qualifier can be missing due to unknown reasons
       // (see https://github.com/liancheng/scalafix-organize-imports/issues/64). In this case, we
       // issue a warning and continue processing assuming that the top qualifier is fully-qualified.
-      || topQualifierSymbol.isNone && {
+      topQualifierSymbol.isNone && {
         diagnostics += ImporterSymbolNotFound(topQualifier)
         true
       }
@@ -342,27 +344,20 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
         // Only `C` is unimported. `A` and `B` are still available.
         //
         // TODO: Shall we issue a warning here as using order-sensitive imports is a bad practice?
-        val lastUnimportsWithWildcard =
-          importeeLists.reverse collectFirst {
-            case Importees(_, _, unimports @ _ :: _, _, _, Some(_)) => unimports
-          }
+        val lastUnimportsWithWildcard = importeeLists.reverse collectFirst {
+          case Importees(_, _, unimports @ _ :: _, _, _, Some(_)) => unimports
+        }
 
-        val lastUnimportsGivenAll =
-          importeeLists.reverse collectFirst {
-            case Importees(_, _, unimports @ _ :: _, _, Some(_), _) => unimports
-          }
+        val lastUnimportsWithGivenAll = importeeLists.reverse collectFirst {
+          case Importees(_, _, unimports @ _ :: _, _, Some(_), _) => unimports
+        }
 
         // Collects all unimports without an accompanying wildcard.
-        val allUnimports = importeeLists.collect { case Importees(_, _, unimports, _, None, None) =>
+        val unimports = importeeLists.collect { case Importees(_, _, unimports, _, None, None) =>
           unimports
         }.flatten
 
-        val isGivenImport: Importee => Boolean = {
-          case _: Importee.Given => true
-          case _                 => false
-        }
-        val allImportees = group flatMap (_.importees.filterNot(isGivenImport))
-        val givens = group.flatMap(_.importees.filter(isGivenImport))
+        val (givens, nonGivens) = group.flatMap(_.importees).toList.partition(_.is[Importee.Given])
 
         // Here we assume that a name is renamed at most once within a single source file, which is
         // true in most cases.
@@ -370,7 +365,7 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
         // Note that the IntelliJ IDEA Scala import optimizer does not handle this case properly
         // either. If a name is renamed more than once, it only keeps one of the renames in the
         // result and may break compilation (unless other renames are not actually referenced).
-        val renames = allImportees
+        val renames = nonGivens
           .collect { case rename: Importee.Rename => rename }
           .groupBy(_.name.value)
           .map {
@@ -401,7 +396,7 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
             from
           }.toSet
 
-          allImportees
+          nonGivens
             .filter(_.is[Importee.Name])
             .groupBy { case Importee.Name(Name(name)) => name }
             .map { case (_, importees) => importees.head }
@@ -409,10 +404,7 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
             .partition { case Importee.Name(Name(name)) => renamedNames contains name }
         }
 
-        val wildcard = Importee.Wildcard()
-        val givenAll = Importee.GivenAll()
-
-        val newImporteeLists = (hasWildcard, lastUnimportsWithWildcard) match {
+        val mergedNonGivens = (hasWildcard, lastUnimportsWithWildcard) match {
           case (true, _) =>
             // A few things to note in this case:
             //
@@ -480,15 +472,15 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
             //      import p.{A => A1, _}
             //
             //    Otherwise, the original name `A` is no longer available.
-            if (aggressive) Seq(renames, wildcard :: Nil)
-            else Seq(renames, importedNames :+ wildcard)
+            if (aggressive) Seq(renames, Wildcard() :: Nil)
+            else Seq(renames, importedNames :+ Wildcard())
 
-          case (false, Some(unimports)) =>
+          case (false, Some(lastUnimports)) =>
             // A wildcard must be appended for unimports.
-            Seq(renamedImportedNames, importedNames ++ renames ++ unimports :+ wildcard)
+            Seq(renamedImportedNames, importedNames ++ renames ++ lastUnimports :+ Wildcard())
 
           case (false, None) =>
-            Seq(renamedImportedNames, importedNames ++ renames ++ allUnimports)
+            Seq(renamedImportedNames, importedNames ++ renames ++ unimports)
         }
 
         /* Adjust the result to add givens imports, these are
@@ -496,14 +488,12 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
          * with the wildcard import.
          */
         val newImporteeListsWithGivens = if (hasGivenAll) {
-          if (aggressive) newImporteeLists :+ List(givenAll)
-          else newImporteeLists :+ (givens :+ givenAll)
+          if (aggressive) mergedNonGivens :+ List(GivenAll())
+          else mergedNonGivens :+ (givens :+ GivenAll())
         } else {
-          lastUnimportsGivenAll match {
-            case Some(unimports) =>
-              newImporteeLists :+ (givens ++ unimports :+ givenAll)
-            case None =>
-              newImporteeLists :+ givens
+          lastUnimportsWithGivenAll match {
+            case Some(unimports) => mergedNonGivens :+ (givens ++ unimports :+ GivenAll())
+            case None            => mergedNonGivens :+ givens
           }
         }
 
@@ -539,8 +529,6 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
     }
 
   private def coalesceImportees(importer: Importer): Importer = {
-    import Importee.{GivenAll, Wildcard}
-
     val Importees(names, renames, unimports, givens, _, _) = importer.importees
 
     config.coalesceToWildcardImportThreshold
@@ -561,12 +549,12 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
 
     // The Scala language spec allows an import expression to have at most one final wildcard, which
     // can only appears in the last position.
-    val (wildcards, noWildcard) =
+    val (wildcards, others) =
       importer.importees partition (i => i.is[Importee.Wildcard] || i.is[Importee.GivenAll])
 
     val orderedImportees = config.importSelectorsOrder match {
-      case Ascii        => Seq(noWildcard, wildcards) map (_.sortBy(_.syntax)) reduce (_ ++ _)
-      case SymbolsFirst => Seq(noWildcard, wildcards) map sortImporteesSymbolsFirst reduce (_ ++ _)
+      case Ascii        => Seq(others, wildcards) map (_.sortBy(_.syntax)) reduce (_ ++ _)
+      case SymbolsFirst => Seq(others, wildcards) map sortImporteesSymbolsFirst reduce (_ ++ _)
       case Keep         => importer.importees
     }
 
@@ -581,9 +569,11 @@ class OrganizeImports(config: OrganizeImportsConfig) extends SemanticRule("Organ
     if (alreadySorted) importer else importer.copy(importees = orderedImportees)
   }
 
-  // Returns the index of the group to which the given importer belongs. Each group is represented
-  // by an `ImportMatcher`. If multiple `ImporterMatcher`s match the given import, the one matches
-  // the longest prefix wins.
+  /**
+   * Returns the index of the group to which the given importer belongs. Each group is represented
+   * by an `ImportMatcher`. If multiple `ImporterMatcher`s match the given import, the one matches
+   * the longest prefix wins.
+   */
   private def matchImportGroup(importer: Importer): Int = {
     val matchedGroups = matchers
       .map(_ matches importer)
@@ -692,6 +682,7 @@ object OrganizeImports {
       if (parsed contains *) parsed else parsed :+ *
     }
 
+    // Inserts a blank line marker between adjacent import groups when `blankLines` is `Auto`.
     config.blankLines match {
       case BlankLines.Manual => withWildcard
       case BlankLines.Auto   => withWildcard.flatMap(_ :: --- :: Nil)
@@ -804,9 +795,8 @@ object OrganizeImports {
         //
         //   import p.{A => _, B => _, C => D, _}
         //   import p.E
-        val importeesList = ((names ++ givens).map(
-          _ :: Nil
-        )) :+ (renames ++ unimports ++ wildcard ++ givenAll)
+        val importeesList =
+          (names ++ givens).map(_ :: Nil) :+ (renames ++ unimports ++ wildcard ++ givenAll)
         importeesList filter (_.nonEmpty) map (Importer(ref, _))
 
       case importer =>

--- a/rules/src/main/scala/fix/OrganizeImports.scala
+++ b/rules/src/main/scala/fix/OrganizeImports.scala
@@ -888,13 +888,15 @@ object OrganizeImports {
     }
 
     /** Returns true if the `Importer` contains a standalone wildcard. */
-    def hasWildcard: Boolean = importer.importees match {
-      case Importees(_, _, unimports, _, _, wildcard) => unimports.isEmpty && wildcard.nonEmpty
+    def hasWildcard: Boolean = {
+      val Importees(_, _, unimports, _, _, wildcard) = importer.importees
+      unimports.isEmpty && wildcard.nonEmpty
     }
 
     /** Returns true if the `Importer` contains a standalone given  wildcard. */
-    def hasGivenAll: Boolean = importer.importees match {
-      case Importees(_, _, unimports, _, givenAll, _) => unimports.isEmpty && givenAll.nonEmpty
+    def hasGivenAll: Boolean = {
+      val Importees(_, _, unimports, _, givenAll, _) = importer.importees
+      unimports.isEmpty && givenAll.nonEmpty
     }
   }
 }


### PR DESCRIPTION
This PR makes a bunch of refactoring changes to simplify the implementation, as well as fixing one bug: when sorting importees, the `SymbolsFirst` option can be violated when `given` imports are there. For example:

```scala
import foo.{given, _}
```

The above import should be rewritten into

```scala
import foo.{_, given}
```

when `importSelectorsOrder` order is set to `SymbolsFirst`.
