### PR TITLE
Preserve the original source-level formatting when possible after exploding imports

### DIFF
--- a/input/src/main/scala/fix/ExplodeImportsFormatPreserving.scala
+++ b/input/src/main/scala/fix/ExplodeImportsFormatPreserving.scala
@@ -1,0 +1,12 @@
+/*
+rules = [OrganizeImports]
+OrganizeImports.removeUnused = false
+OrganizeImports.groupedImports = Explode
+ */
+
+package fix
+
+import fix.ExplodeImports.FormatPreserving.g1.{ a, b }
+import fix.ExplodeImports.FormatPreserving.g2.{ c => C, _ }
+
+object ExplodeImportsFormatPreserving

--- a/output/src/main/scala/fix/ExplodeImportsFormatPreserving.scala
+++ b/output/src/main/scala/fix/ExplodeImportsFormatPreserving.scala
@@ -1,0 +1,7 @@
+package fix
+
+import fix.ExplodeImports.FormatPreserving.g1.a
+import fix.ExplodeImports.FormatPreserving.g1.b
+import fix.ExplodeImports.FormatPreserving.g2.{ c => C, _ }
+
+object ExplodeImportsFormatPreserving

--- a/shared/src/main/scala/fix/ExplodeImports.scala
+++ b/shared/src/main/scala/fix/ExplodeImports.scala
@@ -1,0 +1,60 @@
+package fix
+
+object ExplodeImports {
+  object Wildcard1 {
+    object a
+    object b
+    object c
+    object d
+  }
+
+  object Wildcard2 {
+    object a
+    object b
+  }
+
+  object Unimport1 {
+    object a
+    object b
+    object c
+    object d
+  }
+
+  object Unimport2 {
+    object a
+    object b
+    object c
+    object d
+  }
+
+  object Rename1 {
+    object a
+    object b
+    object c
+    object d
+  }
+
+  object Rename2 {
+    object a
+    object b
+    object c
+  }
+
+  object Dedup {
+    object a
+    object b
+    object c
+  }
+
+  object FormatPreserving {
+    object g1 {
+      object a
+      object b
+    }
+
+    object g2 {
+      object c
+      object d
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes issue https://github.com/liancheng/scalafix-organize-imports/issues/279.